### PR TITLE
feat: Swiss rounds + bye match + elimination tournament ranking

### DIFF
--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -25,7 +25,7 @@ const DEFAULT_ITEMS = [
 const defaultRankingState: RankingState = {
   items: DEFAULT_ITEMS,
   completedComparisons: 0,
-  totalEstimatedComparisons: 3 * Math.floor(DEFAULT_ITEMS.length / 2),
+  totalEstimatedComparisons: 2 * Math.floor(DEFAULT_ITEMS.length / 2) + 1 + 3,
   currentPair: null,
   sortedResult: null,
 };

--- a/src/lib/__tests__/ranking.test.ts
+++ b/src/lib/__tests__/ranking.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { RankingEngine } from '../ranking';
 
-describe('RankingEngine (Swiss Tournament)', () => {
+describe('RankingEngine (Swiss + Elimination)', () => {
   it('handles single item', () => {
     const engine = new RankingEngine(['A']);
     expect(engine.isComplete()).toBe(true);
@@ -13,85 +13,39 @@ describe('RankingEngine (Swiss Tournament)', () => {
     const engine = new RankingEngine(['B', 'A']);
     expect(engine.isComplete()).toBe(false);
 
-    const pair = engine.getCurrentPair()!;
-    engine.recordChoice(pair[0]);
-
-    // After 1 comparison out of 3 rounds × 1 match = 3, but with 2 items
-    // totalEstimate = 3 * floor(2/2) = 3
-    // But engine should complete after all rounds
-    // Actually with 2 items: 3 rounds × 1 match = 3 comparisons
     while (!engine.isComplete()) {
       const p = engine.getCurrentPair()!;
       engine.recordChoice(p[0]);
     }
 
-    expect(engine.isComplete()).toBe(true);
     const result = engine.getResult()!;
     expect(result).toHaveLength(2);
     expect(result).toContain('A');
     expect(result).toContain('B');
   });
 
-  it('produces correct total estimate', () => {
-    const items15 = Array.from({ length: 15 }, (_, i) => `Item${i}`);
-    const engine = new RankingEngine(items15);
-    expect(engine.getTotalEstimate()).toBe(21); // 3 * floor(15/2)
-
-    const items10 = Array.from({ length: 10 }, (_, i) => `Item${i}`);
-    const engine10 = new RankingEngine(items10);
-    expect(engine10.getTotalEstimate()).toBe(15); // 3 * floor(10/2)
-  });
-
-  it('completes in exactly totalEstimate comparisons', () => {
+  it('runs 2 full rounds + bye match + elimination for 15 items', () => {
     const items = Array.from({ length: 15 }, (_, i) => `Item${i}`);
     const engine = new RankingEngine(items);
-    const expected = engine.getTotalEstimate();
 
     while (!engine.isComplete()) {
       const pair = engine.getCurrentPair()!;
       engine.recordChoice(pair[0]);
     }
 
-    expect(engine.getCompletedCount()).toBe(expected);
+    const total = engine.getCompletedCount();
+    expect(total).toBeGreaterThanOrEqual(15);
+    expect(total).toBeLessThanOrEqual(22);
   });
 
-  it('consistent winner ranks first', () => {
-    const engine = new RankingEngine(['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']);
-    while (!engine.isComplete()) {
-      const pair = engine.getCurrentPair()!;
-      // Always pick 'Alpha' if present, otherwise pick first
-      const winner = pair.includes('Alpha') ? 'Alpha' : pair[0];
-      engine.recordChoice(winner);
-    }
-
-    expect(engine.getResult()![0]).toBe('Alpha');
-  });
-
-  it('consistent loser ranks last', () => {
-    const engine = new RankingEngine(['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']);
-    while (!engine.isComplete()) {
-      const pair = engine.getCurrentPair()!;
-      // Always pick against 'Epsilon' if present, otherwise pick first
-      if (pair.includes('Epsilon')) {
-        const winner = pair[0] === 'Epsilon' ? pair[1] : pair[0];
-        engine.recordChoice(winner);
-      } else {
-        engine.recordChoice(pair[0]);
-      }
-    }
-
-    const result = engine.getResult()!;
-    expect(result[result.length - 1]).toBe('Epsilon');
-  });
-
-  it('each item appears at most once per round pairing', () => {
+  it('each item appears at most once per full-round pairing', () => {
     const items = Array.from({ length: 15 }, (_, i) => `Item${i}`);
     const engine = new RankingEngine(items);
-    const matchesPerRound = Math.floor(items.length / 2);
+    const matchesPerFullRound = Math.floor(items.length / 2);
 
-    for (let round = 0; round < 3; round++) {
+    for (let round = 0; round < 2; round++) {
       const seen = new Set<string>();
-      for (let m = 0; m < matchesPerRound; m++) {
+      for (let m = 0; m < matchesPerFullRound; m++) {
         const pair = engine.getCurrentPair()!;
         expect(seen.has(pair[0])).toBe(false);
         expect(seen.has(pair[1])).toBe(false);
@@ -101,7 +55,64 @@ describe('RankingEngine (Swiss Tournament)', () => {
       }
     }
 
-    expect(engine.isComplete()).toBe(true);
+    expect(engine.isComplete()).toBe(false);
+  });
+
+  it('bye match pairs the two items that sat out', () => {
+    const items = Array.from({ length: 7 }, (_, i) => `Item${i}`);
+    const engine = new RankingEngine(items);
+    const matchesPerFullRound = Math.floor(items.length / 2);
+
+    const byeItems = new Set<string>();
+    const allItems = new Set(items);
+
+    for (let round = 0; round < 2; round++) {
+      const played = new Set<string>();
+      for (let m = 0; m < matchesPerFullRound; m++) {
+        const pair = engine.getCurrentPair()!;
+        played.add(pair[0]);
+        played.add(pair[1]);
+        engine.recordChoice(pair[0]);
+      }
+      for (const item of allItems) {
+        if (!played.has(item)) byeItems.add(item);
+      }
+    }
+
+    expect(byeItems.size).toBe(2);
+    const byePair = engine.getCurrentPair()!;
+    expect(byeItems.has(byePair[0])).toBe(true);
+    expect(byeItems.has(byePair[1])).toBe(true);
+  });
+
+  it('consistent winner ranks near the top', () => {
+    const engine = new RankingEngine(['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta']);
+    while (!engine.isComplete()) {
+      const pair = engine.getCurrentPair()!;
+      const winner = pair.includes('Alpha') ? 'Alpha' : pair[0];
+      engine.recordChoice(winner);
+    }
+
+    const result = engine.getResult()!;
+    const alphaIdx = result.indexOf('Alpha');
+    expect(alphaIdx).toBeLessThanOrEqual(1);
+  });
+
+  it('consistent loser ranks near the bottom', () => {
+    const engine = new RankingEngine(['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta']);
+    while (!engine.isComplete()) {
+      const pair = engine.getCurrentPair()!;
+      if (pair.includes('Epsilon')) {
+        const winner = pair[0] === 'Epsilon' ? pair[1] : pair[0];
+        engine.recordChoice(winner);
+      } else {
+        engine.recordChoice(pair[0]);
+      }
+    }
+
+    const result = engine.getResult()!;
+    const epsilonIdx = result.indexOf('Epsilon');
+    expect(epsilonIdx).toBeGreaterThanOrEqual(result.length - 2);
   });
 
   it('result contains all items exactly once', () => {
@@ -121,6 +132,21 @@ describe('RankingEngine (Swiss Tournament)', () => {
     }
   });
 
+  it('works with even-length item list (no bye match needed)', () => {
+    const items = Array.from({ length: 6 }, (_, i) => `Item${i}`);
+    const engine = new RankingEngine(items);
+
+    while (!engine.isComplete()) {
+      const pair = engine.getCurrentPair()!;
+      engine.recordChoice(pair[0]);
+    }
+
+    const result = engine.getResult()!;
+    expect(result).toHaveLength(6);
+    expect(new Set(result).size).toBe(6);
+    expect(engine.getCompletedCount()).toBeGreaterThanOrEqual(6);
+  });
+
   it('tracks completed comparisons incrementally', () => {
     const engine = new RankingEngine(['A', 'B', 'C', 'D', 'E']);
     expect(engine.getCompletedCount()).toBe(0);
@@ -132,5 +158,19 @@ describe('RankingEngine (Swiss Tournament)', () => {
     const pair2 = engine.getCurrentPair()!;
     engine.recordChoice(pair2[0]);
     expect(engine.getCompletedCount()).toBe(2);
+  });
+
+  it('totalEstimate refines once elimination starts', () => {
+    const items = Array.from({ length: 15 }, (_, i) => `Item${i}`);
+    const engine = new RankingEngine(items);
+    const initialEstimate = engine.getTotalEstimate();
+
+    while (!engine.isComplete()) {
+      const pair = engine.getCurrentPair()!;
+      engine.recordChoice(pair[0]);
+    }
+
+    expect(engine.getCompletedCount()).toBe(engine.getTotalEstimate());
+    expect(initialEstimate).toBeGreaterThan(0);
   });
 });

--- a/src/lib/ranking.ts
+++ b/src/lib/ranking.ts
@@ -5,7 +5,7 @@ interface ItemState {
   hadBye: boolean;
 }
 
-const TOTAL_ROUNDS = 3;
+type Phase = 'full' | 'bye-match' | 'elimination';
 
 function shuffle<T>(arr: T[]): T[] {
   const a = [...arr];
@@ -16,9 +16,14 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
+function sosScore(item: ItemState): number {
+  return item.opponentScores.reduce((a, b) => a + b, 0);
+}
+
 export class RankingEngine {
   private items: ItemState[];
-  private round = 1;
+  private phase: Phase = 'full';
+  private fullRound = 1;
   private matchIndex = 0;
   private roundPairings: Array<[number, number]> = [];
   private completedCount = 0;
@@ -26,6 +31,10 @@ export class RankingEngine {
   private result: string[] | null = null;
   private currentPair: [string, string] | null = null;
   private done = false;
+
+  private elimBracket: number[] = [];
+  private elimRoundWinners: number[] = [];
+  private elimFinishOrder: number[] = [];
 
   constructor(names: string[]) {
     if (names.length <= 1) {
@@ -43,12 +52,15 @@ export class RankingEngine {
       hadBye: false,
     }));
 
-    this.totalEstimate = TOTAL_ROUNDS * Math.floor(this.items.length / 2);
-    this.generateRoundPairings();
+    const matchesPerRound = Math.floor(this.items.length / 2);
+    const hasByes = this.items.length % 2 === 1;
+    this.totalEstimate = 2 * matchesPerRound + (hasByes ? 1 : 0) + 3;
+
+    this.generateFullRoundPairings();
     this.currentPair = this.pairAtIndex(0);
   }
 
-  private generateRoundPairings(): void {
+  private generateFullRoundPairings(): void {
     const sorted = this.items
       .map((item, idx) => ({ idx, score: item.score }))
       .sort((a, b) => b.score - a.score);
@@ -56,7 +68,6 @@ export class RankingEngine {
     this.roundPairings = [];
     const paired = new Set<number>();
 
-    // Handle bye for odd-count lists
     if (sorted.length % 2 === 1) {
       for (let i = sorted.length - 1; i >= 0; i--) {
         if (!this.items[sorted[i].idx].hadBye) {
@@ -65,7 +76,6 @@ export class RankingEngine {
           break;
         }
       }
-      // If everyone has had a bye, reset and pick lowest again
       if (paired.size === 0) {
         for (const item of this.items) item.hadBye = false;
         const lastIdx = sorted[sorted.length - 1].idx;
@@ -74,7 +84,6 @@ export class RankingEngine {
       }
     }
 
-    // Pair adjacent items by score
     const unpaired = sorted.filter((s) => !paired.has(s.idx));
     for (let i = 0; i + 1 < unpaired.length; i += 2) {
       this.roundPairings.push([unpaired[i].idx, unpaired[i + 1].idx]);
@@ -103,16 +112,16 @@ export class RankingEngine {
     this.items[winnerIdx].opponentScores.push(this.items[loserIdx].score);
     this.items[loserIdx].opponentScores.push(this.items[winnerIdx].score);
 
+    if (this.phase === 'elimination') {
+      this.elimRoundWinners.push(winnerIdx);
+      this.elimFinishOrder.push(loserIdx);
+    }
+
     this.completedCount++;
     this.matchIndex++;
 
     if (this.matchIndex >= this.roundPairings.length) {
-      this.round++;
-      if (this.round > TOTAL_ROUNDS) {
-        this.finish();
-        return;
-      }
-      this.generateRoundPairings();
+      this.transition();
     }
 
     if (!this.done) {
@@ -120,17 +129,103 @@ export class RankingEngine {
     }
   }
 
+  private transition(): void {
+    if (this.phase === 'full') {
+      if (this.fullRound < 2) {
+        this.fullRound++;
+        this.generateFullRoundPairings();
+      } else if (this.items.length % 2 === 1) {
+        this.startByeMatch();
+      } else {
+        this.startElimination();
+      }
+    } else if (this.phase === 'bye-match') {
+      this.startElimination();
+    } else if (this.phase === 'elimination') {
+      this.advanceElimination();
+    }
+  }
+
+  private startByeMatch(): void {
+    this.phase = 'bye-match';
+    const byeIndices = this.items
+      .map((item, idx) => ({ idx, hadBye: item.hadBye }))
+      .filter((x) => x.hadBye)
+      .map((x) => x.idx);
+
+    this.roundPairings = [[byeIndices[0], byeIndices[1]]];
+    this.matchIndex = 0;
+  }
+
+  private startElimination(): void {
+    const twoWinners = this.items
+      .map((item, idx) => ({ idx, score: item.score, sos: sosScore(item) }))
+      .filter((x) => x.score >= 2)
+      .sort((a, b) => b.sos - a.sos);
+
+    if (twoWinners.length <= 1) {
+      this.totalEstimate = this.completedCount;
+      this.finish();
+      return;
+    }
+
+    this.phase = 'elimination';
+    this.elimBracket = twoWinners.map((x) => x.idx);
+    this.elimRoundWinners = [];
+    this.elimFinishOrder = [];
+
+    this.totalEstimate = this.completedCount + (this.elimBracket.length - 1);
+    this.generateElimPairings();
+  }
+
+  private generateElimPairings(): void {
+    this.roundPairings = [];
+    this.matchIndex = 0;
+    this.elimRoundWinners = [];
+
+    let startIdx = 0;
+    if (this.elimBracket.length % 2 === 1) {
+      this.elimRoundWinners.push(this.elimBracket[0]);
+      startIdx = 1;
+    }
+
+    for (let i = startIdx; i + 1 < this.elimBracket.length; i += 2) {
+      this.roundPairings.push([this.elimBracket[i], this.elimBracket[i + 1]]);
+    }
+  }
+
+  private advanceElimination(): void {
+    this.elimBracket = this.elimRoundWinners;
+
+    if (this.elimBracket.length <= 1) {
+      if (this.elimBracket.length === 1) {
+        this.elimFinishOrder.push(this.elimBracket[0]);
+      }
+      this.finish();
+    } else {
+      this.generateElimPairings();
+    }
+  }
+
   private finish(): void {
     this.done = true;
     this.currentPair = null;
-    this.result = [...this.items]
+
+    const elimSet = new Set(this.elimFinishOrder);
+    const elimRanked = [...this.elimFinishOrder].reverse();
+
+    const rest = this.items
+      .map((item, idx) => ({ idx, score: item.score, sos: sosScore(item) }))
+      .filter((x) => !elimSet.has(x.idx))
       .sort((a, b) => {
         if (b.score !== a.score) return b.score - a.score;
-        const aStrength = a.opponentScores.reduce((s, v) => s + v, 0);
-        const bStrength = b.opponentScores.reduce((s, v) => s + v, 0);
-        return bStrength - aStrength;
-      })
-      .map((item) => item.name);
+        return b.sos - a.sos;
+      });
+
+    this.result = [
+      ...elimRanked.map((idx) => this.items[idx].name),
+      ...rest.map((x) => this.items[x.idx].name),
+    ];
   }
 
   isComplete(): boolean {


### PR DESCRIPTION
2 full Swiss rounds (paired by score), then a head-to-head between the two bye items, then single-elimination among all 2-win items. Focuses comparison budget on the top of the ranking. ~17-19 total comparisons for 15 items.