### PR TITLE
Deterministic questions, deferred API key, next-steps page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Career Genie
 
-AI career coaching wizard: setup → hub → [questions + ranking] → career chat.
+AI career coaching wizard: welcome → hub → [questions + ranking] → next steps → (optionally) career chat.
 
 ## Stack
 
@@ -16,19 +16,21 @@ Next.js 16, React 19, TypeScript, Tailwind CSS 4, Vitest. Deployed on Vercel.
 ## Architecture
 
 - All user state in React Context (`src/context/SessionContext.tsx`, useReducer pattern)
-- Hub-and-spoke workflow: Setup → Hub → [Questions + Ranking] → Career Chat
-- 5 independent LLM sessions for reflection questions (`src/app/questions/page.tsx`)
+- Hub-and-spoke workflow: Welcome → Hub → [Questions + Ranking] → Next Steps → (optionally) Career Chat
+- 5 deterministic reflection questions with optional "Why?" follow-up (`src/app/questions/page.tsx`)
 - One API route (`src/app/api/chat/route.ts`) proxies LLM requests to Anthropic/OpenAI with streaming
 - Browser-side stream parsing in `src/lib/llm-client.ts`
 - Swiss-style tournament ranking in `src/lib/ranking.ts`
 - System prompts in `src/lib/prompts.ts`
+- Export to .md with YAML frontmatter and copyable prompt in `src/lib/export.ts`
 
 ## Key Patterns
 
-- User's API key is passed per-request, never stored server-side
-- Each reflection question is an independent LLM session (fresh conversation per question)
+- API key is only needed for in-app career chat (deferred to next-steps page)
+- Reflection questions are deterministic (no LLM) — answer + optional "Why?"
 - Steps 1 (Questions) and 2 (Ranking) can be completed in any order via the hub page
-- Step 3 (Career Chat) receives all Q&A answers and rankings as context
+- After both steps, user chooses: in-app chat (with API key + optional resume) or download/copy results
+- Career Chat receives all Q&A answers, rankings, and optional resume as context
 - Ranking uses Swiss-style tournament (yields pairs, accepts choices)
 
 ## Plan

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -24,7 +24,7 @@ export default function ChatPage() {
     let content = '';
 
     try {
-      const contextMessages = buildChatContextMessages(state.questionResponses, rankedQualities);
+      const contextMessages = buildChatContextMessages(state.questionResponses, rankedQualities, state.resumeText);
       for await (const chunk of sendMessage({
         provider: state.provider,
         apiKey: state.apiKey,
@@ -55,8 +55,8 @@ export default function ChatPage() {
   }
 
   useEffect(() => {
-    if (!isStep3Available(state)) {
-      router.replace(state.wizardStep === 'setup' ? '/' : '/hub');
+    if (!isStep3Available(state) || !state.apiKey) {
+      router.replace(state.wizardStep === 'setup' ? '/' : '/next-steps');
       return;
     }
 

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession, areQuestionsComplete, isRankingComplete, isStep3Available } from '@/context/SessionContext';
-import { buildExportText, downloadTextFile } from '@/lib/export';
 import { WizardNav } from '@/components/WizardNav';
 
 export default function HubPage() {
@@ -20,7 +19,6 @@ export default function HubPage() {
   const rankingComplete = isRankingComplete(state);
   const chatAvailable = isStep3Available(state);
   const questionsAnswered = state.questionResponses.filter((qr) => qr.isComplete).length;
-  const hasAnyData = questionsAnswered > 0 || rankingComplete;
 
   function goToQuestions() {
     dispatch({ type: 'SET_WIZARD_STEP', step: 'questions' });
@@ -32,19 +30,9 @@ export default function HubPage() {
     router.push('/rank');
   }
 
-  function goToChat() {
-    dispatch({ type: 'SET_WIZARD_STEP', step: 'chat' });
-    router.push('/chat');
-  }
-
-  function handleDownload() {
-    const text = buildExportText(
-      state.questionResponses,
-      state.rankingState.sortedResult,
-    );
-    if (text) {
-      downloadTextFile(text, 'career-genie-results.txt');
-    }
+  function goToNextSteps() {
+    dispatch({ type: 'SET_WIZARD_STEP', step: 'next-steps' });
+    router.push('/next-steps');
   }
 
   return (
@@ -112,7 +100,7 @@ export default function HubPage() {
           </button>
 
           <button
-            onClick={goToChat}
+            onClick={goToNextSteps}
             disabled={!chatAvailable}
             className={`w-full rounded-xl py-3 text-sm font-medium transition-all ${
               chatAvailable
@@ -120,17 +108,8 @@ export default function HubPage() {
                 : 'bg-gray-100 text-gray-400 cursor-not-allowed'
             }`}
           >
-            {chatAvailable ? 'Continue to Career Chat' : 'Complete both steps to continue'}
+            {chatAvailable ? 'See Your Results' : 'Complete both steps to continue'}
           </button>
-
-          {hasAnyData && (
-            <button
-              onClick={handleDownload}
-              className="w-full rounded-xl py-2.5 text-sm font-medium text-gray-600 border border-gray-300 hover:border-gray-400 hover:text-gray-800 transition-colors"
-            >
-              Download My Results
-            </button>
-          )}
         </div>
       </div>
     </main>

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -108,7 +108,7 @@ export default function HubPage() {
                 : 'bg-gray-100 text-gray-400 cursor-not-allowed'
             }`}
           >
-            {chatAvailable ? 'See Your Results' : 'Complete both steps to continue'}
+            {chatAvailable ? 'Proceed to Coaching' : 'Complete both steps to continue'}
           </button>
         </div>
       </div>

--- a/src/app/next-steps/page.tsx
+++ b/src/app/next-steps/page.tsx
@@ -161,7 +161,7 @@ export default function NextStepsPage() {
                 <div>
                   <h2 className="text-lg font-semibold text-gray-900">Copy Prompt</h2>
                   <p className="mt-2 text-sm text-gray-500">
-                    Copy a ready-made prompt to use in ChatGPT, Claude, or any AI chat tool.
+                    Continue your coaching session in ChatGPT, Claude, Gemini, or any other AI chat tool. This prompt includes all your answers and rankings as context.
                   </p>
                 </div>
                 <button
@@ -176,7 +176,7 @@ export default function NextStepsPage() {
                 <div>
                   <h2 className="text-lg font-semibold text-gray-900">Download Results</h2>
                   <p className="mt-2 text-sm text-gray-500">
-                    Download your results as Markdown. Re-upload to Career Genie later to continue your session.
+                    Download your answers and rankings in Markdown format.
                   </p>
                 </div>
                 <button

--- a/src/app/next-steps/page.tsx
+++ b/src/app/next-steps/page.tsx
@@ -156,32 +156,36 @@ export default function NextStepsPage() {
             </div>
 
             {/* Option B: Take Your Results */}
-            <div className="rounded-2xl border-2 border-gray-200 p-6 space-y-4">
-              <h2 className="text-lg font-semibold text-gray-900">Take Your Results</h2>
-              <p className="text-sm text-gray-500">
-                Download your results or copy a prompt to use in your preferred AI chat tool.
-              </p>
-
-              <div className="space-y-3 pt-2">
-                <button
-                  onClick={handleDownloadMarkdown}
-                  className="w-full rounded-xl py-3 text-sm font-medium text-gray-700 border border-gray-300 hover:border-gray-400 hover:text-gray-900 transition-colors"
-                >
-                  Download as Markdown (.md)
-                </button>
-
+            <div className="flex flex-col gap-6">
+              <div className="flex-1 rounded-2xl border-2 border-gray-200 p-6 flex flex-col justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900">Copy Prompt</h2>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Copy a ready-made prompt to use in ChatGPT, Claude, or any AI chat tool.
+                  </p>
+                </div>
                 <button
                   onClick={handleCopyPrompt}
-                  className="w-full rounded-xl py-3 text-sm font-medium text-gray-700 border border-gray-300 hover:border-gray-400 hover:text-gray-900 transition-colors"
+                  className="w-full rounded-xl py-3 text-sm font-medium text-gray-700 border border-gray-300 hover:border-gray-400 hover:text-gray-900 transition-colors mt-4"
                 >
                   {copied ? 'Copied!' : 'Copy Prompt to Clipboard'}
                 </button>
               </div>
 
-              <p className="text-xs text-gray-400">
-                The copied prompt works with ChatGPT, Claude, or any AI chat tool. The .md file
-                can be re-uploaded to Career Genie in the future to continue your session.
-              </p>
+              <div className="flex-1 rounded-2xl border-2 border-gray-200 p-6 flex flex-col justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-900">Download Results</h2>
+                  <p className="mt-2 text-sm text-gray-500">
+                    Download your results as Markdown. Re-upload to Career Genie later to continue your session.
+                  </p>
+                </div>
+                <button
+                  onClick={handleDownloadMarkdown}
+                  className="w-full rounded-xl py-3 text-sm font-medium text-gray-700 border border-gray-300 hover:border-gray-400 hover:text-gray-900 transition-colors mt-4"
+                >
+                  Download as Markdown (.md)
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/next-steps/page.tsx
+++ b/src/app/next-steps/page.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession, isStep3Available } from '@/context/SessionContext';
+import { buildExportMarkdown, buildCopyablePrompt, downloadTextFile } from '@/lib/export';
+import { WizardNav } from '@/components/WizardNav';
+import type { Provider } from '@/types';
+
+export default function NextStepsPage() {
+  const { state, dispatch } = useSession();
+  const router = useRouter();
+  const [error, setError] = useState('');
+  const [validating, setValidating] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const rankedQualities = state.rankingState.sortedResult || [];
+
+  useEffect(() => {
+    if (!isStep3Available(state)) {
+      router.replace(state.wizardStep === 'setup' ? '/' : '/hub');
+    }
+  }, [state, router]);
+
+  async function validateAndStartChat() {
+    if (!state.apiKey.trim()) {
+      setError('Please enter an API key.');
+      return;
+    }
+
+    setValidating(true);
+    setError('');
+
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: state.provider,
+          apiKey: state.apiKey,
+          systemPrompt: 'Reply with exactly: ok',
+          messages: [{ role: 'user', content: 'Hello' }],
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || `Validation failed (${response.status})`);
+      }
+
+      dispatch({ type: 'SET_WIZARD_STEP', step: 'chat' });
+      router.push('/chat');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to validate API key.');
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  function handleDownloadMarkdown() {
+    const md = buildExportMarkdown(state.questionResponses, rankedQualities);
+    if (md) {
+      downloadTextFile(md, 'career-genie-results.md');
+    }
+  }
+
+  async function handleCopyPrompt() {
+    const prompt = buildCopyablePrompt(state.questionResponses, rankedQualities);
+    await navigator.clipboard.writeText(prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col">
+      <WizardNav />
+      <div className="flex-1 flex items-center justify-center px-4 py-8">
+        <div className="w-full max-w-2xl space-y-8">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-gray-900">Your Results Are Ready</h1>
+            <p className="mt-2 text-gray-600">
+              Choose how you&apos;d like to continue with your career insights.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Option A: Continue In-App */}
+            <div className="rounded-2xl border-2 border-gray-200 p-6 space-y-4">
+              <h2 className="text-lg font-semibold text-gray-900">Continue In-App</h2>
+              <p className="text-sm text-gray-500">
+                Get personalized AI coaching based on your answers and priorities.
+              </p>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  LLM Provider
+                </label>
+                <div className="flex gap-2">
+                  {(['anthropic', 'openai'] as Provider[]).map((p) => (
+                    <button
+                      key={p}
+                      onClick={() => dispatch({ type: 'SET_PROVIDER', provider: p })}
+                      className={`flex-1 rounded-xl py-2 text-sm font-medium border transition-colors ${
+                        state.provider === p
+                          ? 'bg-blue-600 text-white border-blue-600'
+                          : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'
+                      }`}
+                    >
+                      {p === 'anthropic' ? 'Anthropic' : 'OpenAI'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="api-key" className="block text-sm font-medium text-gray-700 mb-2">
+                  API Key
+                </label>
+                <input
+                  id="api-key"
+                  type="password"
+                  value={state.apiKey}
+                  onChange={(e) => dispatch({ type: 'SET_API_KEY', apiKey: e.target.value })}
+                  placeholder={state.provider === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
+                  className="w-full rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+              </div>
+
+              <div>
+                <label htmlFor="resume" className="block text-sm font-medium text-gray-700 mb-2">
+                  Resume <span className="text-gray-400 font-normal">(optional)</span>
+                </label>
+                <textarea
+                  id="resume"
+                  value={state.resumeText}
+                  onChange={(e) => dispatch({ type: 'SET_RESUME_TEXT', resumeText: e.target.value })}
+                  placeholder="Paste your resume text here for more personalized advice..."
+                  rows={4}
+                  className="w-full rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+                />
+              </div>
+
+              {error && <p className="text-sm text-red-600">{error}</p>}
+
+              <button
+                onClick={validateAndStartChat}
+                disabled={validating}
+                className="w-full rounded-xl bg-blue-600 py-3 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >
+                {validating ? 'Validating...' : 'Start Career Chat'}
+              </button>
+
+              <p className="text-xs text-gray-400">
+                Your API key is used directly in your browser and never stored on any server.
+              </p>
+            </div>
+
+            {/* Option B: Take Your Results */}
+            <div className="rounded-2xl border-2 border-gray-200 p-6 space-y-4">
+              <h2 className="text-lg font-semibold text-gray-900">Take Your Results</h2>
+              <p className="text-sm text-gray-500">
+                Download your results or copy a prompt to use in your preferred AI chat tool.
+              </p>
+
+              <div className="space-y-3 pt-2">
+                <button
+                  onClick={handleDownloadMarkdown}
+                  className="w-full rounded-xl py-3 text-sm font-medium text-gray-700 border border-gray-300 hover:border-gray-400 hover:text-gray-900 transition-colors"
+                >
+                  Download as Markdown (.md)
+                </button>
+
+                <button
+                  onClick={handleCopyPrompt}
+                  className="w-full rounded-xl py-3 text-sm font-medium text-gray-700 border border-gray-300 hover:border-gray-400 hover:text-gray-900 transition-colors"
+                >
+                  {copied ? 'Copied!' : 'Copy Prompt to Clipboard'}
+                </button>
+              </div>
+
+              <p className="text-xs text-gray-400">
+                The copied prompt works with ChatGPT, Claude, or any AI chat tool. The .md file
+                can be re-uploaded to Career Genie in the future to continue your session.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,8 +26,8 @@ export default function WelcomePage() {
           <div className="space-y-3">
             <p className="text-sm text-gray-500">
               You&apos;ll answer 5 reflection questions and rank your career
-              priorities. Then start an open-ended conversation in this app
-              or in your AI Chat app of choice.
+              priorities. Then start an open-ended coaching session in
+              this app or in your AI Chat app of choice.
             </p>
             <button
               onClick={handleStart}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,116 +1,41 @@
 'use client';
 
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@/context/SessionContext';
 import { WizardNav } from '@/components/WizardNav';
-import type { Provider } from '@/types';
 
-export default function SetupPage() {
-  const { state, dispatch } = useSession();
+export default function WelcomePage() {
+  const { dispatch } = useSession();
   const router = useRouter();
-  const [error, setError] = useState('');
-  const [validating, setValidating] = useState(false);
 
-  async function validateAndProceed() {
-    if (!state.apiKey.trim()) {
-      setError('Please enter an API key.');
-      return;
-    }
-
-    setValidating(true);
-    setError('');
-
-    try {
-      const response = await fetch('/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          provider: state.provider,
-          apiKey: state.apiKey,
-          systemPrompt: 'Reply with exactly: ok',
-          messages: [{ role: 'user', content: 'Hello' }],
-        }),
-      });
-
-      if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        throw new Error(body.error || `Validation failed (${response.status})`);
-      }
-
-      dispatch({ type: 'SET_WIZARD_STEP', step: 'hub' });
-      router.push('/hub');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to validate API key.');
-    } finally {
-      setValidating(false);
-    }
+  function handleStart() {
+    dispatch({ type: 'SET_WIZARD_STEP', step: 'hub' });
+    router.push('/hub');
   }
 
   return (
     <main className="min-h-screen flex flex-col">
       <WizardNav />
       <div className="flex-1 flex items-center justify-center px-4">
-        <div className="w-full max-w-md space-y-6">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold">Career Genie</h1>
-            <p className="mt-2 text-gray-600">
-              AI-powered career coaching. Bring your own API key.
+        <div className="w-full max-w-md space-y-6 text-center">
+          <h1 className="text-3xl font-bold text-gray-900">Career Genie</h1>
+          <p className="text-gray-600">
+            Discover what matters most in your career through guided reflection
+            and personalized coaching.
+          </p>
+          <div className="space-y-3">
+            <p className="text-sm text-gray-500">
+              You&apos;ll answer 5 reflection questions and rank your career
+              priorities. Then choose to get AI-powered coaching or take your
+              results with you.
             </p>
-          </div>
-
-          <div className="space-y-4 bg-white rounded-2xl p-6 shadow-sm border border-gray-200">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                LLM Provider
-              </label>
-              <div className="flex gap-2">
-                {(['anthropic', 'openai'] as Provider[]).map((p) => (
-                  <button
-                    key={p}
-                    onClick={() => dispatch({ type: 'SET_PROVIDER', provider: p })}
-                    className={`flex-1 rounded-xl py-2.5 text-sm font-medium border transition-colors ${
-                      state.provider === p
-                        ? 'bg-blue-600 text-white border-blue-600'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-gray-400'
-                    }`}
-                  >
-                    {p === 'anthropic' ? 'Anthropic (Claude)' : 'OpenAI (GPT)'}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor="api-key" className="block text-sm font-medium text-gray-700 mb-2">
-                API Key
-              </label>
-              <input
-                id="api-key"
-                type="password"
-                value={state.apiKey}
-                onChange={(e) => dispatch({ type: 'SET_API_KEY', apiKey: e.target.value })}
-                placeholder={state.provider === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
-                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-              />
-            </div>
-
-            {error && (
-              <p className="text-sm text-red-600">{error}</p>
-            )}
-
             <button
-              onClick={validateAndProceed}
-              disabled={validating}
-              className="w-full rounded-xl bg-blue-600 py-3 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              onClick={handleStart}
+              className="w-full rounded-xl bg-blue-600 py-3 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
             >
-              {validating ? 'Validating...' : 'Start Coaching Session'}
+              Get Started
             </button>
           </div>
-
-          <p className="text-xs text-center text-gray-400">
-            Your API key is used directly in your browser and never stored on any server.
-          </p>
         </div>
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,8 +26,8 @@ export default function WelcomePage() {
           <div className="space-y-3">
             <p className="text-sm text-gray-500">
               You&apos;ll answer 5 reflection questions and rank your career
-              priorities. Then choose to get AI-powered coaching or take your
-              results with you.
+              priorities. Then start an open-ended conversation in this app
+              or in your AI Chat app of choice.
             </p>
             <button
               onClick={handleStart}

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -98,7 +98,7 @@ export default function QuestionsPage() {
           <h2 className="text-lg font-semibold text-gray-900">{currentQuestion.question}</h2>
         </div>
 
-        <div className="flex-1 flex flex-col justify-center py-8 space-y-6">
+        <div className="py-6 space-y-6">
           {phase === 'answer' && (
             <>
               <textarea

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -16,10 +16,23 @@ export default function QuestionsPage() {
   });
   const [phase, setPhase] = useState<Phase>('answer');
   const [inputValue, setInputValue] = useState('');
+  const [prevInputKey, setPrevInputKey] = useState('0-answer');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const currentQuestion = state.questionResponses[currentQuestionIndex];
   const isLastQuestion = currentQuestionIndex === state.questionResponses.length - 1;
+
+  const inputKey = `${currentQuestionIndex}-${phase}`;
+  if (prevInputKey !== inputKey) {
+    setPrevInputKey(inputKey);
+    if (currentQuestion.answer && phase === 'answer') {
+      setInputValue(currentQuestion.answer);
+    } else if (currentQuestion.whyAnswer && phase === 'why') {
+      setInputValue(currentQuestion.whyAnswer);
+    } else {
+      setInputValue('');
+    }
+  }
 
   useEffect(() => {
     if (state.wizardStep === 'setup') {
@@ -30,16 +43,6 @@ export default function QuestionsPage() {
   useEffect(() => {
     textareaRef.current?.focus();
   }, [currentQuestionIndex, phase]);
-
-  useEffect(() => {
-    if (currentQuestion.answer && phase === 'answer') {
-      setInputValue(currentQuestion.answer);
-    } else if (currentQuestion.whyAnswer && phase === 'why') {
-      setInputValue(currentQuestion.whyAnswer);
-    } else {
-      setInputValue('');
-    }
-  }, [currentQuestionIndex, phase, currentQuestion.answer, currentQuestion.whyAnswer]);
 
   function handleSubmitAnswer() {
     const trimmed = inputValue.trim();

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -3,13 +3,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from '@/context/SessionContext';
-import { sendMessage } from '@/lib/llm-client';
-import { buildQuestionSystemPrompt } from '@/lib/prompts';
-import { ChatMessage } from '@/components/ChatMessage';
-import { ChatInput } from '@/components/ChatInput';
 import { WizardNav } from '@/components/WizardNav';
 
-const NEXT_MARKER = '[NEXT]';
+type Phase = 'answer' | 'why';
 
 export default function QuestionsPage() {
   const { state, dispatch } = useSession();
@@ -18,13 +14,12 @@ export default function QuestionsPage() {
     const firstIncomplete = state.questionResponses.findIndex((qr) => !qr.isComplete);
     return firstIncomplete >= 0 ? firstIncomplete : 0;
   });
-  const [streaming, setStreaming] = useState(false);
-  const [streamingContent, setStreamingContent] = useState('');
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [phase, setPhase] = useState<Phase>('answer');
+  const [inputValue, setInputValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const currentQuestion = state.questionResponses[currentQuestionIndex];
   const isLastQuestion = currentQuestionIndex === state.questionResponses.length - 1;
-  const hasUserMessage = currentQuestion.messages.some((m) => m.role === 'user');
 
   useEffect(() => {
     if (state.wizardStep === 'setup') {
@@ -33,55 +28,37 @@ export default function QuestionsPage() {
   }, [state.wizardStep, router]);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [currentQuestion.messages, streamingContent]);
+    textareaRef.current?.focus();
+  }, [currentQuestionIndex, phase]);
 
-  async function handleSend(text: string) {
-    const userMessage = { role: 'user' as const, content: text };
-    dispatch({
-      type: 'ADD_QUESTION_MESSAGE',
-      questionId: currentQuestionIndex,
-      message: userMessage,
-    });
-
-    const allMessages = [...currentQuestion.messages, userMessage];
-    setStreaming(true);
-    let content = '';
-
-    try {
-      for await (const chunk of sendMessage({
-        provider: state.provider,
-        apiKey: state.apiKey,
-        systemPrompt: buildQuestionSystemPrompt(currentQuestion.question),
-        messages: allMessages,
-      })) {
-        content += chunk;
-        setStreamingContent(content);
-      }
-
-      const hasNext = content.includes(NEXT_MARKER);
-      const cleanContent = content.replace(NEXT_MARKER, '').trim();
-
-      dispatch({
-        type: 'ADD_QUESTION_MESSAGE',
-        questionId: currentQuestionIndex,
-        message: { role: 'assistant', content: cleanContent },
-      });
-
-      if (hasNext) {
-        advanceQuestion();
-      }
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : 'Something went wrong';
-      dispatch({
-        type: 'ADD_QUESTION_MESSAGE',
-        questionId: currentQuestionIndex,
-        message: { role: 'assistant', content: `Error: ${errorMsg}` },
-      });
-    } finally {
-      setStreaming(false);
-      setStreamingContent('');
+  useEffect(() => {
+    if (currentQuestion.answer && phase === 'answer') {
+      setInputValue(currentQuestion.answer);
+    } else if (currentQuestion.whyAnswer && phase === 'why') {
+      setInputValue(currentQuestion.whyAnswer);
+    } else {
+      setInputValue('');
     }
+  }, [currentQuestionIndex, phase, currentQuestion.answer, currentQuestion.whyAnswer]);
+
+  function handleSubmitAnswer() {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    dispatch({ type: 'SET_QUESTION_ANSWER', questionId: currentQuestionIndex, answer: trimmed });
+    setInputValue('');
+    setPhase('why');
+  }
+
+  function handleSubmitWhy() {
+    const trimmed = inputValue.trim();
+    if (trimmed) {
+      dispatch({ type: 'SET_QUESTION_WHY', questionId: currentQuestionIndex, whyAnswer: trimmed });
+    }
+    advanceQuestion();
+  }
+
+  function handleSkipWhy() {
+    advanceQuestion();
   }
 
   function advanceQuestion() {
@@ -91,6 +68,19 @@ export default function QuestionsPage() {
       router.push('/hub');
     } else {
       setCurrentQuestionIndex(currentQuestionIndex + 1);
+      setPhase('answer');
+      setInputValue('');
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (phase === 'answer') {
+        handleSubmitAnswer();
+      } else {
+        handleSubmitWhy();
+      }
     }
   }
 
@@ -105,29 +95,65 @@ export default function QuestionsPage() {
           <h2 className="text-lg font-semibold text-gray-900">{currentQuestion.question}</h2>
         </div>
 
-        <div className="flex-1 overflow-y-auto py-4 space-y-1">
-          {currentQuestion.messages.map((msg, i) => (
-            <ChatMessage key={i} message={msg} />
-          ))}
-          {streaming && streamingContent && (
-            <ChatMessage message={{ role: 'assistant', content: streamingContent }} />
+        <div className="flex-1 flex flex-col justify-center py-8 space-y-6">
+          {phase === 'answer' && (
+            <>
+              <textarea
+                ref={textareaRef}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Type your answer..."
+                rows={4}
+                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+              />
+              <button
+                onClick={handleSubmitAnswer}
+                disabled={!inputValue.trim()}
+                className={`w-full rounded-xl py-3 text-sm font-medium transition-all ${
+                  inputValue.trim()
+                    ? 'bg-blue-600 text-white hover:bg-blue-700'
+                    : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                }`}
+              >
+                Continue
+              </button>
+            </>
           )}
-          <div ref={messagesEndRef} />
-        </div>
 
-        <div className="sticky bottom-0 bg-gray-50 pt-2 pb-4 space-y-3">
-          <ChatInput onSend={handleSend} disabled={streaming} placeholder="Type your answer..." />
-          <button
-            onClick={advanceQuestion}
-            disabled={!hasUserMessage || streaming}
-            className={`w-full rounded-xl py-2.5 text-sm font-medium transition-all ${
-              hasUserMessage && !streaming
-                ? 'bg-green-600 text-white hover:bg-green-700 shadow-md'
-                : 'bg-gray-100 text-gray-400 cursor-not-allowed'
-            }`}
-          >
-            {isLastQuestion ? 'Finish Questions' : 'Next Question →'}
-          </button>
+          {phase === 'why' && (
+            <>
+              <div className="bg-blue-50 rounded-xl p-4">
+                <p className="text-sm text-gray-700">
+                  <span className="font-medium">Your answer:</span> {currentQuestion.answer}
+                </p>
+              </div>
+              <p className="text-base font-medium text-gray-900">Why?</p>
+              <textarea
+                ref={textareaRef}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Tell us why... (optional)"
+                rows={3}
+                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+              />
+              <div className="flex gap-3">
+                <button
+                  onClick={handleSkipWhy}
+                  className="flex-1 rounded-xl py-3 text-sm font-medium text-gray-600 border border-gray-300 hover:border-gray-400 transition-colors"
+                >
+                  Skip
+                </button>
+                <button
+                  onClick={handleSubmitWhy}
+                  className="flex-1 rounded-xl py-3 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                >
+                  {isLastQuestion ? 'Finish Questions' : 'Next Question'}
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </main>

--- a/src/components/WizardNav.tsx
+++ b/src/components/WizardNav.tsx
@@ -4,9 +4,9 @@ import { useSession, areQuestionsComplete, isRankingComplete } from '@/context/S
 import type { WizardStep } from '@/types';
 
 const STEPS: { key: string; label: string }[] = [
-  { key: 'setup', label: 'Setup' },
+  { key: 'welcome', label: 'Welcome' },
   { key: 'discover', label: 'Discover' },
-  { key: 'chat', label: 'Career Chat' },
+  { key: 'results', label: 'Results' },
 ];
 
 function getStepIndex(wizardStep: WizardStep): number {

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -41,9 +41,11 @@ export const initialState: SessionState = {
   questionResponses: PREDEFINED_QUESTIONS.map((q, i) => ({
     questionId: i,
     question: q,
-    messages: [],
+    answer: '',
+    whyAnswer: '',
     isComplete: false,
   })),
+  resumeText: '',
   chatMessages: [],
   systemPrompt: '',
   rankingState: defaultRankingState,
@@ -60,15 +62,12 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       return { ...state, wizardStep: action.step };
     case 'ADD_CHAT_MESSAGE':
       return { ...state, chatMessages: [...state.chatMessages, action.message] };
-    case 'ADD_QUESTION_MESSAGE':
-      return {
-        ...state,
-        questionResponses: state.questionResponses.map((qr) =>
-          qr.questionId === action.questionId
-            ? { ...qr, messages: [...qr.messages, action.message] }
-            : qr
-        ),
-      };
+    case 'SET_QUESTION_ANSWER':
+      return { ...state, questionResponses: state.questionResponses.map((qr) => qr.questionId === action.questionId ? { ...qr, answer: action.answer } : qr) };
+    case 'SET_QUESTION_WHY':
+      return { ...state, questionResponses: state.questionResponses.map((qr) => qr.questionId === action.questionId ? { ...qr, whyAnswer: action.whyAnswer } : qr) };
+    case 'SET_RESUME_TEXT':
+      return { ...state, resumeText: action.resumeText };
     case 'SET_QUESTION_COMPLETE':
       return {
         ...state,

--- a/src/context/__tests__/SessionContext.test.tsx
+++ b/src/context/__tests__/SessionContext.test.tsx
@@ -3,93 +3,60 @@ import { sessionReducer, initialState, areQuestionsComplete, isStep3Available } 
 
 describe('sessionReducer', () => {
   it('sets provider', () => {
-    const state = sessionReducer(initialState, {
-      type: 'SET_PROVIDER',
-      provider: 'openai',
-    });
+    const state = sessionReducer(initialState, { type: 'SET_PROVIDER', provider: 'openai' });
     expect(state.provider).toBe('openai');
   });
 
   it('sets API key', () => {
-    const state = sessionReducer(initialState, {
-      type: 'SET_API_KEY',
-      apiKey: 'sk-test-123',
-    });
+    const state = sessionReducer(initialState, { type: 'SET_API_KEY', apiKey: 'sk-test-123' });
     expect(state.apiKey).toBe('sk-test-123');
   });
 
   it('sets wizard step', () => {
-    const state = sessionReducer(initialState, {
-      type: 'SET_WIZARD_STEP',
-      step: 'hub',
-    });
+    const state = sessionReducer(initialState, { type: 'SET_WIZARD_STEP', step: 'hub' });
     expect(state.wizardStep).toBe('hub');
   });
 
   it('adds chat message', () => {
     const message = { role: 'user' as const, content: 'Hello' };
-    const state = sessionReducer(initialState, {
-      type: 'ADD_CHAT_MESSAGE',
-      message,
-    });
+    const state = sessionReducer(initialState, { type: 'ADD_CHAT_MESSAGE', message });
     expect(state.chatMessages).toHaveLength(1);
     expect(state.chatMessages[0]).toEqual(message);
   });
 
-  it('adds a message to a specific question', () => {
-    const message = { role: 'user' as const, content: 'I would travel the world' };
-    const state = sessionReducer(initialState, {
-      type: 'ADD_QUESTION_MESSAGE',
-      questionId: 0,
-      message,
-    });
-    expect(state.questionResponses[0].messages).toHaveLength(1);
-    expect(state.questionResponses[0].messages[0]).toEqual(message);
-    expect(state.questionResponses[1].messages).toHaveLength(0);
+  it('sets a question answer', () => {
+    const state = sessionReducer(initialState, { type: 'SET_QUESTION_ANSWER', questionId: 0, answer: 'Travel the world' });
+    expect(state.questionResponses[0].answer).toBe('Travel the world');
+    expect(state.questionResponses[1].answer).toBe('');
   });
 
-  it('adds multiple messages to the same question', () => {
-    let state = sessionReducer(initialState, {
-      type: 'ADD_QUESTION_MESSAGE',
-      questionId: 1,
-      message: { role: 'user' as const, content: 'Start a business' },
-    });
-    state = sessionReducer(state, {
-      type: 'ADD_QUESTION_MESSAGE',
-      questionId: 1,
-      message: { role: 'assistant' as const, content: 'That sounds exciting!' },
-    });
-    expect(state.questionResponses[1].messages).toHaveLength(2);
+  it('sets a question why answer', () => {
+    const state = sessionReducer(initialState, { type: 'SET_QUESTION_WHY', questionId: 2, whyAnswer: 'Because I love exploring' });
+    expect(state.questionResponses[2].whyAnswer).toBe('Because I love exploring');
+    expect(state.questionResponses[0].whyAnswer).toBe('');
   });
 
   it('marks a question as complete', () => {
-    const state = sessionReducer(initialState, {
-      type: 'SET_QUESTION_COMPLETE',
-      questionId: 2,
-    });
+    const state = sessionReducer(initialState, { type: 'SET_QUESTION_COMPLETE', questionId: 2 });
     expect(state.questionResponses[2].isComplete).toBe(true);
     expect(state.questionResponses[0].isComplete).toBe(false);
   });
 
+  it('sets resume text', () => {
+    const state = sessionReducer(initialState, { type: 'SET_RESUME_TEXT', resumeText: 'My resume content...' });
+    expect(state.resumeText).toBe('My resume content...');
+  });
+
   it('merges partial ranking state', () => {
-    const state = sessionReducer(initialState, {
-      type: 'SET_RANKING_STATE',
-      rankingState: { completedComparisons: 5 },
-    });
+    const state = sessionReducer(initialState, { type: 'SET_RANKING_STATE', rankingState: { completedComparisons: 5 } });
     expect(state.rankingState.completedComparisons).toBe(5);
     expect(state.rankingState.items).toEqual(initialState.rankingState.items);
   });
 
   it('resets to initial state', () => {
-    let state = sessionReducer(initialState, {
-      type: 'SET_API_KEY',
-      apiKey: 'sk-test',
-    });
-    state = sessionReducer(state, {
-      type: 'ADD_QUESTION_MESSAGE',
-      questionId: 0,
-      message: { role: 'user' as const, content: 'test' },
-    });
+    let state = sessionReducer(initialState, { type: 'SET_API_KEY', apiKey: 'sk-test' });
+    state = sessionReducer(state, { type: 'SET_QUESTION_ANSWER', questionId: 0, answer: 'test answer' });
+    state = sessionReducer(state, { type: 'SET_RESUME_TEXT', resumeText: 'resume' });
     state = sessionReducer(state, { type: 'RESET' });
     expect(state).toEqual(initialState);
   });
@@ -114,11 +81,7 @@ describe('derived state helpers', () => {
       state = sessionReducer(state, { type: 'SET_QUESTION_COMPLETE', questionId: i });
     }
     expect(isStep3Available(state)).toBe(false);
-
-    state = sessionReducer(state, {
-      type: 'SET_RANKING_STATE',
-      rankingState: { sortedResult: ['A', 'B', 'C'] },
-    });
+    state = sessionReducer(state, { type: 'SET_RANKING_STATE', rankingState: { sortedResult: ['A', 'B', 'C'] } });
     expect(isStep3Available(state)).toBe(true);
   });
 });

--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -1,62 +1,89 @@
 import { describe, it, expect } from 'vitest';
-import { buildExportText } from '../export';
+import { buildExportMarkdown, buildExportText, buildCopyablePrompt } from '../export';
+
+describe('buildExportMarkdown', () => {
+  it('formats answered questions and rankings as markdown', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'What would you do?', answer: 'Travel the world', whyAnswer: 'I love exploring', isComplete: true },
+      { questionId: 1, question: 'Unanswered', answer: '', whyAnswer: '', isComplete: false },
+    ];
+    const rankings = ['Salary', 'Growth', 'Balance'];
+
+    const md = buildExportMarkdown(questionResponses, rankings);
+    expect(md).toContain('---\ngenerated:');
+    expect(md).toContain('app: career-genie');
+    expect(md).toContain('version: 1');
+    expect(md).toContain('# Career Genie Results');
+    expect(md).toContain('### What would you do?');
+    expect(md).toContain('**Answer:** Travel the world');
+    expect(md).toContain('**Why:** I love exploring');
+    expect(md).not.toContain('Unanswered');
+    expect(md).toContain('## Priority Rankings');
+    expect(md).toContain('1. Salary');
+    expect(md).toContain('3. Balance');
+  });
+
+  it('omits why when empty', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'Answer only', whyAnswer: '', isComplete: true },
+    ];
+    const md = buildExportMarkdown(questionResponses, null);
+    expect(md).toContain('**Answer:** Answer only');
+    expect(md).not.toContain('**Why:**');
+  });
+
+  it('returns empty string when no data', () => {
+    const md = buildExportMarkdown([], null);
+    expect(md).toBe('');
+  });
+});
 
 describe('buildExportText', () => {
   it('formats answered questions and rankings', () => {
     const questionResponses = [
-      {
-        questionId: 0,
-        question: 'What would you do?',
-        messages: [
-          { role: 'user' as const, content: 'Travel the world' },
-          { role: 'assistant' as const, content: 'Why is that?' },
-          { role: 'user' as const, content: 'I love exploring' },
-        ],
-        isComplete: true,
-      },
-      {
-        questionId: 1,
-        question: 'Unanswered question',
-        messages: [],
-        isComplete: false,
-      },
+      { questionId: 0, question: 'What would you do?', answer: 'Travel the world', whyAnswer: 'I love exploring', isComplete: true },
+      { questionId: 1, question: 'Unanswered', answer: '', whyAnswer: '', isComplete: false },
     ];
     const rankings = ['Salary', 'Growth', 'Balance'];
 
     const text = buildExportText(questionResponses, rankings);
     expect(text).toContain('REFLECTION QUESTIONS');
     expect(text).toContain('Q: What would you do?');
-    expect(text).toContain('You: Travel the world');
-    expect(text).toContain('Coach: Why is that?');
-    expect(text).toContain('You: I love exploring');
-    expect(text).not.toContain('Unanswered question');
+    expect(text).toContain('Answer: Travel the world');
+    expect(text).toContain('Why: I love exploring');
+    expect(text).not.toContain('Unanswered');
     expect(text).toContain('PRIORITY RANKINGS');
     expect(text).toContain('1. Salary');
-    expect(text).toContain('3. Balance');
   });
 
   it('returns empty string when no data', () => {
-    const text = buildExportText([], null);
-    expect(text).toBe('');
+    expect(buildExportText([], null)).toBe('');
   });
+});
 
-  it('works with only questions completed', () => {
+describe('buildCopyablePrompt', () => {
+  it('includes Q&A and rankings in a self-contained prompt', () => {
     const questionResponses = [
-      {
-        questionId: 0,
-        question: 'Q1',
-        messages: [{ role: 'user' as const, content: 'Answer' }],
-        isComplete: true,
-      },
+      { questionId: 0, question: 'What would you do?', answer: 'Travel', whyAnswer: 'Freedom', isComplete: true },
     ];
-    const text = buildExportText(questionResponses, null);
-    expect(text).toContain('REFLECTION QUESTIONS');
-    expect(text).not.toContain('PRIORITY RANKINGS');
+    const rankings = ['Salary', 'Growth'];
+
+    const prompt = buildCopyablePrompt(questionResponses, rankings);
+    expect(prompt).toContain('career coach');
+    expect(prompt).toContain('Q: What would you do?');
+    expect(prompt).toContain('A: Travel');
+    expect(prompt).toContain('Why: Freedom');
+    expect(prompt).toContain('1. Salary');
+    expect(prompt).toContain('2. Growth');
+    expect(prompt).toContain('suggest 2-3 concrete career paths');
   });
 
-  it('works with only rankings completed', () => {
-    const text = buildExportText([], ['A', 'B']);
-    expect(text).toContain('PRIORITY RANKINGS');
-    expect(text).not.toContain('REFLECTION QUESTIONS');
+  it('works with no why answer', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'Answer', whyAnswer: '', isComplete: true },
+    ];
+    const prompt = buildCopyablePrompt(questionResponses, []);
+    expect(prompt).toContain('A: Answer');
+    expect(prompt).not.toContain('Why:');
   });
 });

--- a/src/lib/__tests__/prompts.test.ts
+++ b/src/lib/__tests__/prompts.test.ts
@@ -1,34 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildQuestionSystemPrompt, buildChatContextMessages } from '../prompts';
-
-describe('buildQuestionSystemPrompt', () => {
-  it('includes the question text in the prompt', () => {
-    const prompt = buildQuestionSystemPrompt("What's play for you but work for others?");
-    expect(prompt).toContain("What's play for you but work for others?");
-    expect(prompt).toContain('Career Genie');
-  });
-
-  it('returns a non-empty string for any question', () => {
-    const prompt = buildQuestionSystemPrompt('Any question here?');
-    expect(prompt.length).toBeGreaterThan(50);
-  });
-});
+import { buildChatContextMessages } from '../prompts';
 
 describe('buildChatContextMessages', () => {
   it('formats question responses and rankings into a context message', () => {
     const questionResponses = [
-      {
-        questionId: 0,
-        question: 'What would you do?',
-        messages: [{ role: 'user' as const, content: 'Travel the world' }],
-        isComplete: true,
-      },
-      {
-        questionId: 1,
-        question: "What if you couldn't fail?",
-        messages: [{ role: 'user' as const, content: 'Start a company' }],
-        isComplete: true,
-      },
+      { questionId: 0, question: 'What would you do?', answer: 'Travel the world', whyAnswer: 'I love freedom', isComplete: true },
+      { questionId: 1, question: "What if you couldn't fail?", answer: 'Start a company', whyAnswer: '', isComplete: true },
     ];
     const rankings = ['Salary', 'Growth', 'Balance'];
 
@@ -37,33 +14,33 @@ describe('buildChatContextMessages', () => {
     expect(result[0].role).toBe('user');
     expect(result[0].content).toContain('What would you do?');
     expect(result[0].content).toContain('Travel the world');
+    expect(result[0].content).toContain('Why: I love freedom');
     expect(result[0].content).toContain('1. Salary');
     expect(result[0].content).toContain('3. Balance');
   });
 
-  it('handles questions with no user messages', () => {
+  it('handles unanswered questions', () => {
     const questionResponses = [
-      { questionId: 0, question: 'Q1', messages: [], isComplete: false },
+      { questionId: 0, question: 'Q1', answer: '', whyAnswer: '', isComplete: false },
     ];
     const result = buildChatContextMessages(questionResponses, []);
     expect(result[0].content).toContain('(not answered)');
   });
 
-  it('concatenates multiple user messages for the same question', () => {
+  it('includes resume text when provided', () => {
     const questionResponses = [
-      {
-        questionId: 0,
-        question: 'Q1',
-        messages: [
-          { role: 'user' as const, content: 'First thought' },
-          { role: 'assistant' as const, content: 'Tell me more' },
-          { role: 'user' as const, content: 'Second thought' },
-        ],
-        isComplete: true,
-      },
+      { questionId: 0, question: 'Q1', answer: 'Answer', whyAnswer: '', isComplete: true },
     ];
-    const result = buildChatContextMessages(questionResponses, []);
-    expect(result[0].content).toContain('First thought');
-    expect(result[0].content).toContain('Second thought');
+    const result = buildChatContextMessages(questionResponses, ['A'], 'My resume text here');
+    expect(result[0].content).toContain('Here is my resume:');
+    expect(result[0].content).toContain('My resume text here');
+  });
+
+  it('omits resume section when empty', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'Answer', whyAnswer: '', isComplete: true },
+    ];
+    const result = buildChatContextMessages(questionResponses, ['A'], '');
+    expect(result[0].content).not.toContain('resume');
   });
 });

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,5 +1,72 @@
 import type { QuestionResponse } from '@/types';
 
+export function buildExportMarkdown(
+  questionResponses: QuestionResponse[],
+  rankedQualities: string[] | null,
+): string {
+  const sections: string[] = [];
+
+  const now = new Date().toISOString().split('T')[0];
+  sections.push(`---\ngenerated: ${now}\napp: career-genie\nversion: 1\n---`);
+  sections.push('# Career Genie Results');
+
+  const answeredQuestions = questionResponses.filter((qr) => qr.answer.trim() !== '');
+
+  if (answeredQuestions.length > 0) {
+    const qaLines = answeredQuestions.map((qr) => {
+      let block = `### ${qr.question}\n\n**Answer:** ${qr.answer}`;
+      if (qr.whyAnswer.trim()) {
+        block += `\n\n**Why:** ${qr.whyAnswer}`;
+      }
+      return block;
+    });
+    sections.push('## Reflection Questions\n\n' + qaLines.join('\n\n'));
+  }
+
+  if (rankedQualities && rankedQualities.length > 0) {
+    const rankingLines = rankedQualities.map((q, i) => `${i + 1}. ${q}`);
+    sections.push('## Priority Rankings (most to least important)\n\n' + rankingLines.join('\n'));
+  }
+
+  if (sections.length <= 2) return '';
+
+  return sections.join('\n\n') + '\n';
+}
+
+export function buildCopyablePrompt(
+  questionResponses: QuestionResponse[],
+  rankedQualities: string[] | null,
+): string {
+  const parts: string[] = [];
+
+  parts.push(
+    'I completed a career self-reflection exercise. Based on my answers and priorities below, please act as a career coach and give me personalized, actionable career advice.',
+  );
+
+  const answeredQuestions = questionResponses.filter((qr) => qr.answer.trim() !== '');
+  if (answeredQuestions.length > 0) {
+    const qaBlock = answeredQuestions.map((qr) => {
+      let entry = `Q: ${qr.question}\nA: ${qr.answer}`;
+      if (qr.whyAnswer.trim()) {
+        entry += `\nWhy: ${qr.whyAnswer}`;
+      }
+      return entry;
+    }).join('\n\n');
+    parts.push('## My Reflection Answers\n\n' + qaBlock);
+  }
+
+  if (rankedQualities && rankedQualities.length > 0) {
+    const rankingBlock = rankedQualities.map((q, i) => `${i + 1}. ${q}`).join('\n');
+    parts.push('## My Career Priorities (most to least important)\n\n' + rankingBlock);
+  }
+
+  parts.push(
+    'Please suggest 2-3 concrete career paths or next steps that align with my answers and priorities. Reference specific things I shared. Acknowledge trade-offs honestly.',
+  );
+
+  return parts.join('\n\n');
+}
+
 export function buildExportText(
   questionResponses: QuestionResponse[],
   rankedQualities: string[] | null,
@@ -7,15 +74,16 @@ export function buildExportText(
   const sections: string[] = [];
 
   const answeredQuestions = questionResponses.filter(
-    (qr) => qr.isComplete && qr.messages.some((m) => m.role === 'user'),
+    (qr) => qr.answer.trim() !== '',
   );
 
   if (answeredQuestions.length > 0) {
     const qaLines = answeredQuestions.map((qr) => {
-      const conversation = qr.messages
-        .map((m) => (m.role === 'user' ? `  You: ${m.content}` : `  Coach: ${m.content}`))
-        .join('\n');
-      return `Q: ${qr.question}\n${conversation}`;
+      let block = `Q: ${qr.question}\n  Answer: ${qr.answer}`;
+      if (qr.whyAnswer.trim()) {
+        block += `\n  Why: ${qr.whyAnswer}`;
+      }
+      return block;
     });
     sections.push('REFLECTION QUESTIONS\n\n' + qaLines.join('\n\n'));
   }

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,34 +1,16 @@
 import type { QuestionResponse, ChatMessage } from '@/types';
 
-export function buildQuestionSystemPrompt(question: string): string {
-  return `You are Career Genie, a warm and insightful career coach. The user was asked the following reflection question:
-
-"${question}"
-
-Guidelines:
-- Acknowledge their response warmly and specifically (reference what they said).
-- If their answer is vague or very brief, ask one brief follow-up question to draw out more detail.
-- If their answer is detailed and thoughtful, affirm what they shared and offer a brief reflection.
-- Keep your responses to 2-3 sentences.
-- Do NOT ask unrelated questions or change the topic.
-- Do NOT provide career advice yet — that comes later.
-
-Completion signal:
-- Once the user has given a clear, substantive answer to the question (typically after answering your follow-up "why" as well), include the exact marker [NEXT] at the very end of your message, after your visible text.
-- Do NOT include [NEXT] if the user's answer is still vague, confused, or incomplete.
-- Do NOT explain the [NEXT] marker to the user.
-- A typical flow is: user answers → you ask why → user explains why → you affirm and include [NEXT]. But use your judgment — some answers are complete in one turn.`;
-}
-
 export const CHAT_SYSTEM_PROMPT = `You are Career Genie, providing personalized career coaching based on the user's self-reflection answers and their ranked job preferences.
 
 You will receive:
-1. The user's answers to 5 career reflection questions (each with the question and their response)
+1. The user's answers to 5 career reflection questions (each with the question, their answer, and optionally why)
 2. The user's ranked list of job qualities (from most to least important)
+3. Optionally, the user's resume text
 
 Provide actionable, specific career advice that:
 - References specific things the user shared in their answers
 - Aligns recommendations with their top-ranked preferences
+- If a resume is provided, connect their experience to potential directions
 - Suggests 2-3 concrete career paths or next steps
 - Acknowledges trade-offs honestly (e.g., "Your top priority is salary, but you also value mission-driven work — here's how to balance that")
 - Keeps advice grounded and realistic
@@ -38,14 +20,16 @@ Format your response with clear sections. Be direct but supportive. After your i
 export function buildChatContextMessages(
   questionResponses: QuestionResponse[],
   rankedQualities: string[],
+  resumeText?: string,
 ): ChatMessage[] {
   const qaSummary = questionResponses
     .map((qr) => {
-      const userMessages = qr.messages
-        .filter((m) => m.role === 'user')
-        .map((m) => m.content)
-        .join('\n');
-      return `Question: "${qr.question}"\nAnswer: ${userMessages || '(not answered)'}`;
+      if (!qr.answer.trim()) return `Question: "${qr.question}"\nAnswer: (not answered)`;
+      let entry = `Question: "${qr.question}"\nAnswer: ${qr.answer}`;
+      if (qr.whyAnswer.trim()) {
+        entry += `\nWhy: ${qr.whyAnswer}`;
+      }
+      return entry;
     })
     .join('\n\n');
 
@@ -53,10 +37,13 @@ export function buildChatContextMessages(
     .map((q, i) => `${i + 1}. ${q}`)
     .join('\n');
 
-  return [
-    {
-      role: 'user' as const,
-      content: `Here are my answers to the career reflection questions:\n\n${qaSummary}\n\nAnd here are my job qualities ranked from most to least important:\n\n${rankingSummary}\n\nBased on all of this, what career advice do you have for me?`,
-    },
-  ];
+  let content = `Here are my answers to the career reflection questions:\n\n${qaSummary}\n\nAnd here are my job qualities ranked from most to least important:\n\n${rankingSummary}`;
+
+  if (resumeText && resumeText.trim()) {
+    content += `\n\nHere is my resume:\n\n${resumeText.trim()}`;
+  }
+
+  content += '\n\nBased on all of this, what career advice do you have for me?';
+
+  return [{ role: 'user' as const, content }];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export type Provider = 'anthropic' | 'openai';
 
-export type WizardStep = 'setup' | 'hub' | 'questions' | 'rank' | 'chat';
+export type WizardStep = 'setup' | 'hub' | 'questions' | 'rank' | 'next-steps' | 'chat';
 
 export interface ChatMessage {
   role: 'user' | 'assistant';
@@ -10,7 +10,8 @@ export interface ChatMessage {
 export interface QuestionResponse {
   questionId: number;
   question: string;
-  messages: ChatMessage[];
+  answer: string;
+  whyAnswer: string;
   isComplete: boolean;
 }
 
@@ -27,6 +28,7 @@ export interface SessionState {
   apiKey: string;
   wizardStep: WizardStep;
   questionResponses: QuestionResponse[];
+  resumeText: string;
   chatMessages: ChatMessage[];
   systemPrompt: string;
   rankingState: RankingState;
@@ -38,8 +40,10 @@ export type SessionAction =
   | { type: 'SET_API_KEY'; apiKey: string }
   | { type: 'SET_WIZARD_STEP'; step: WizardStep }
   | { type: 'ADD_CHAT_MESSAGE'; message: ChatMessage }
-  | { type: 'ADD_QUESTION_MESSAGE'; questionId: number; message: ChatMessage }
+  | { type: 'SET_QUESTION_ANSWER'; questionId: number; answer: string }
+  | { type: 'SET_QUESTION_WHY'; questionId: number; whyAnswer: string }
   | { type: 'SET_QUESTION_COMPLETE'; questionId: number }
   | { type: 'SET_RANKING_STATE'; rankingState: Partial<RankingState> }
+  | { type: 'SET_RESUME_TEXT'; resumeText: string }
   | { type: 'SET_RESULTS'; results: string }
   | { type: 'RESET' };


### PR DESCRIPTION
## Summary

Restructure the app to make reflection questions deterministic (no LLM), defer API key entry until after both steps complete, and add a new next-steps page with two paths: continue in-app or export results.

### Key changes

- **Deterministic questions** — Replaced LLM-driven question sessions with a simple form flow: question → answer textarea → hardcoded "Why?" follow-up (optional, can skip) → next question. No API calls needed.
- **Deferred API key** — Removed API key/provider from the welcome page. Welcome is now just intro text + "Get Started". API key and provider selection moved to the new next-steps page.
- **New `/next-steps` page** — Appears after both Questions and Ranking are complete. Two cards:
  - **Continue In-App**: Provider toggle + API key input + optional resume paste → validates key → starts career chat with full context (Q&A + rankings + resume)
  - **Take Your Results**: Download as `.md` (YAML frontmatter for future re-import) or copy a self-contained prompt to clipboard for use in any AI chat app
- **Resume support** — Optional plain-text resume paste on next-steps page, passed to career chat LLM context
- **Export functions** — New `buildExportMarkdown()` (structured .md with frontmatter), `buildCopyablePrompt()` (self-contained prompt), updated `buildExportText()`
- **Updated types** — `QuestionResponse` uses `answer`/`whyAnswer` strings instead of `messages: ChatMessage[]`. New `SET_QUESTION_ANSWER`, `SET_QUESTION_WHY`, `SET_RESUME_TEXT` actions. New `'next-steps'` wizard step.
- **WizardNav** — Steps renamed to "Welcome → Discover → Results"
- **Hub** — CTA button says "Proceed to Coaching", navigates to `/next-steps`
- **Ranking consolidation** — Combined related qualities (flexible hours + work-life balance, career growth + leadership) from 15 to 13 items

### Files changed (14 files, +616 −324)

| File | Change |
|------|--------|
| `src/types/index.ts` | New question/action types, `resumeText`, `'next-steps'` step |
| `src/context/SessionContext.tsx` | New reducer cases, updated initialState |
| `src/context/__tests__/SessionContext.test.tsx` | Tests for new actions |
| `src/lib/export.ts` | New `buildExportMarkdown`, `buildCopyablePrompt`, `downloadTextFile` |
| `src/lib/__tests__/export.test.ts` | Tests for all export functions |
| `src/lib/prompts.ts` | Removed question prompt, updated chat context for resume |
| `src/lib/__tests__/prompts.test.ts` | Updated for new function signatures |
| `src/app/page.tsx` | Simplified to welcome screen |
| `src/app/hub/page.tsx` | Navigate to `/next-steps`, updated button text |
| `src/app/questions/page.tsx` | Deterministic form flow (no LLM) |
| `src/app/next-steps/page.tsx` | **New** — in-app chat or export options |
| `src/app/chat/page.tsx` | Resume in context, gate on API key |
| `src/components/WizardNav.tsx` | Updated step labels |
| `CLAUDE.md` | Updated architecture docs |

## Test plan

- [ ] Welcome page loads with intro text and "Get Started" (no API key form)
- [ ] Hub shows both step cards with correct completion status
- [ ] Questions flow: answer → optional "Why?" → next, through all 5
- [ ] Questions preserve answers when navigating back
- [ ] Ranking works unchanged
- [ ] "Proceed to Coaching" disabled until both steps complete
- [ ] Next-steps page shows two cards after both steps complete
- [ ] Download .md includes YAML frontmatter, Q&A, and rankings
- [ ] Copy prompt produces self-contained text in clipboard
- [ ] API key validates before starting career chat
- [ ] Career chat receives Q&A + rankings + resume as context
- [ ] All 35 tests pass, build succeeds, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)