### PR TITLE
refine prompt

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -17,8 +17,7 @@ export default function ChatPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const initializedRef = useRef(false);
 
-  const rankedQualities = state.rankingState.sortedResult || [];
-  const systemPrompt = buildChatSystemPrompt(state.questionResponses, rankedQualities, state.resumeText);
+  const systemPrompt = buildChatSystemPrompt(state.questionResponses, state.rankingState.sortedResult || [], state.resumeText);
 
   async function generateInitialAdvice() {
     setStreaming(true);
@@ -107,43 +106,25 @@ export default function ChatPage() {
   return (
     <main className="min-h-screen flex flex-col">
 
-      <div className="flex-1 flex max-w-5xl mx-auto w-full px-4 gap-6 py-4">
-        <aside className="w-64 shrink-0 hidden md:block">
-          <div className="sticky top-4 bg-white rounded-2xl border border-stone-200 p-4">
-            <h3 className="font-semibold text-sm text-stone-900 mb-3">Your Rankings</h3>
-            <ol className="space-y-1.5">
-              {rankedQualities.map((q, i) => (
-                <li key={q} className="flex gap-2 text-sm">
-                  <span className="text-stone-400 w-5 text-right shrink-0">{i + 1}.</span>
-                  <span className={i < 5 ? 'text-stone-900 font-medium' : 'text-stone-600'}>
-                    {q}
-                  </span>
-                </li>
-              ))}
-            </ol>
-          </div>
-        </aside>
+      <div className="flex-1 flex flex-col max-w-3xl mx-auto w-full px-4 py-4">
+        <div className="flex-1 overflow-y-auto space-y-1">
+          {state.chatMessages
+            .filter((msg) => !(msg.role === 'user' && msg.content === CHAT_KICKOFF_MESSAGE.content))
+            .map((msg, i) => (
+              <ChatMessage key={i} message={msg} />
+            ))}
+          {streaming && streamingContent && (
+            <ChatMessage message={{ role: 'assistant', content: streamingContent }} />
+          )}
+          <div ref={messagesEndRef} />
+        </div>
 
-        <div className="flex-1 flex flex-col min-w-0">
-          <div className="flex-1 overflow-y-auto space-y-1">
-            {state.chatMessages
-              .filter((msg) => !(msg.role === 'user' && msg.content === CHAT_KICKOFF_MESSAGE.content))
-              .map((msg, i) => (
-                <ChatMessage key={i} message={msg} />
-              ))}
-            {streaming && streamingContent && (
-              <ChatMessage message={{ role: 'assistant', content: streamingContent }} />
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-
-          <div className="sticky bottom-0 bg-stone-50 pt-2 pb-4">
-            <ChatInput
-              onSend={handleSend}
-              disabled={streaming}
-              placeholder="Ask a follow-up question..."
-            />
-          </div>
+        <div className="sticky bottom-0 bg-stone-50 pt-2 pb-4">
+          <ChatInput
+            onSend={handleSend}
+            disabled={streaming}
+            placeholder="Ask a follow-up question..."
+          />
         </div>
       </div>
     </main>

--- a/src/app/next-steps/page.tsx
+++ b/src/app/next-steps/page.tsx
@@ -77,9 +77,9 @@ export default function NextStepsPage() {
       <div className="flex-1 flex items-center justify-center px-4 py-8">
         <div className="w-full max-w-2xl space-y-8">
           <div className="text-center">
-            <h1 className="text-2xl font-bold text-stone-900">Your Results Are Ready</h1>
+            <h1 className="text-2xl font-bold text-stone-900">Your Genie Awaits</h1>
             <p className="mt-2 text-stone-600">
-              Choose how you&apos;d like to continue with your career insights.
+              Choose an option below to continue.
             </p>
           </div>
 
@@ -88,7 +88,7 @@ export default function NextStepsPage() {
             <div className="rounded-2xl border-2 border-stone-200 p-6 space-y-4">
               <h2 className="text-lg font-semibold text-stone-900">Continue In-App</h2>
               <p className="text-sm text-stone-500">
-                Get personalized AI coaching based on your answers and priorities.
+                Get personalized coaching based on your answers, rankings, and resume.
               </p>
 
               <div>

--- a/src/app/next-steps/page.tsx
+++ b/src/app/next-steps/page.tsx
@@ -65,7 +65,7 @@ export default function NextStepsPage() {
   }
 
   async function handleCopyPrompt() {
-    const prompt = buildCopyablePrompt(state.questionResponses, rankedQualities);
+    const prompt = buildCopyablePrompt(state.questionResponses, rankedQualities, state.resumeText);
     await navigator.clipboard.writeText(prompt);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,8 +61,7 @@ export default function WelcomePage() {
         <div className="w-full max-w-md space-y-6 text-center">
           <h1 className="text-3xl font-bold text-stone-900">Career Genie</h1>
           <p className="text-stone-600">
-            Discover what matters most in your career through guided reflection
-            and personalized coaching.
+            A wise and powerful genie will help you create a plan to achieve your dream job.
           </p>
           <div className="space-y-3">
             <p className="text-sm text-stone-500">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,6 +87,8 @@ export default function WelcomePage() {
               className="text-sm text-emerald-600 hover:text-emerald-700 underline cursor-pointer"
             >
               Resume a previous session
+              <br />
+              <span className="text-xs text-stone-500 no-underline">(by uploading a .md file from a previous session)</span>
             </button>
             <input
               ref={fileInputRef}

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,4 +1,5 @@
 import type { QuestionResponse } from '@/types';
+import { buildChatSystemPrompt } from '@/lib/prompts';
 
 export function buildExportMarkdown(
   questionResponses: QuestionResponse[],
@@ -36,35 +37,10 @@ export function buildExportMarkdown(
 export function buildCopyablePrompt(
   questionResponses: QuestionResponse[],
   rankedQualities: string[] | null,
+  resumeText?: string,
 ): string {
-  const parts: string[] = [];
-
-  parts.push(
-    'I completed a career self-reflection exercise. Based on my answers and priorities below, please act as a career coach and give me personalized, actionable career advice.',
-  );
-
-  const answeredQuestions = questionResponses.filter((qr) => qr.answer.trim() !== '');
-  if (answeredQuestions.length > 0) {
-    const qaBlock = answeredQuestions.map((qr) => {
-      let entry = `Q: ${qr.question}\nA: ${qr.answer}`;
-      if (qr.whyAnswer.trim()) {
-        entry += `\nWhy: ${qr.whyAnswer}`;
-      }
-      return entry;
-    }).join('\n\n');
-    parts.push('## My Reflection Answers\n\n' + qaBlock);
-  }
-
-  if (rankedQualities && rankedQualities.length > 0) {
-    const rankingBlock = rankedQualities.map((q, i) => `${i + 1}. ${q}`).join('\n');
-    parts.push('## My Career Priorities (most to least important)\n\n' + rankingBlock);
-  }
-
-  parts.push(
-    'Please suggest 2-3 concrete career paths or next steps that align with my answers and priorities. Reference specific things I shared. Acknowledge trade-offs honestly.',
-  );
-
-  return parts.join('\n\n');
+  return buildChatSystemPrompt(questionResponses, rankedQualities || [], resumeText)
+    + '\n\nPlease begin the coaching session.';
 }
 
 export function buildExportText(

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -2,17 +2,31 @@ import type { QuestionResponse, ChatMessage } from '@/types';
 
 const CHAT_SYSTEM_PROMPT_TEMPLATE = `You are a clever and wise career coach. Your goal is to help the user create a plan to achieve their "dream job" within 5 years (or as close to it as is realistic). Note: a dream job may not be a job at all but could be owning their own business, or multiple jobs, etc…
 
-Using the Socratic method, ask them questions that will ultimately have them create this plan. Only prompt with your own suggestions if the user is clearly stuck or explicitly asks you for suggestions, otherwise let the user choose their path through their own answers.
-
 Here are results from a survey the user has already taken:
 
 <survey_results>
 {{SURVEY_RESULTS}}
 </survey_results>
 
-Now, using the Socratic method as much as possible, first determine what is the user's "dream job" and then help them create a path towards it.
+Your sub-tasks are:
+0. Obtain Resume
+1. Identify dream job
+2. Plan to achieve the dream job: help the user formulate a plan to achieve their dream job, or something close to it
 
-If the user's resume is not already included in the survey results, start by asking for the user's current resume to determine the current state of affairs. Otherwise, begin the conversation with a question of your choice.`;
+Sub-task details
+
+0. Obtain Resume
+  0a. If the survey results don't already include the user's resume, ask for it.
+  0b. If the survey results already include a resume, skip this step.
+
+1. Identify dream job: help the user identify what their (realistic) dream job is
+  1a. Create 4 realistic "dream job" scenarios based on the user's survey results and current resume. Each of these should be realistically acheivable within 5 years by the user you are coaching.
+  1b. Prompt the user "Imagine it is ____, five years from now. You are at dinner with a smart friend who knows you well. They ask, 'So what are you doing these days?' You give an answer that makes you feel proud - not performatively proud, but quietly certain that you made great career choices. Which of these 4 scenarios would make you feel that way?"
+  1c. Ask the user questions to refine the scenario they chose, iterating until you have defined a "dream job" scenario which is realistically acheivable within 5 years.
+
+2. Plan to achieve the dream job: help the user formulate a plan to achieve their dream job, or something close to it
+  2a. Using the Socratic method as much as possible, help the user construct a plan which, starting from where they are currently, gives them the best chance of achieving their "dream job" or something close to it.
+  2b. Try to have the user create their own plan by answering your questions, but prompt them with suggestions if they get completely stuck`;
 
 export function buildChatSystemPrompt(
   questionResponses: QuestionResponse[],


### PR DESCRIPTION
# PR: Dinner Party Prompt

## Summary

- Refined the coaching system prompt with structured sub-tasks: obtain resume, identify dream job via a "dinner party" scenario, and build a plan using the Socratic method
- Updated copy across the app to lean into the genie theme ("Your Genie Awaits", landing page subtitle, resume session hint)
- Removed the "Your Rankings" sidebar from the chat view so the page focuses on the conversation
- Unified the "Copy Prompt" output with the in-app chat system prompt so users get the same coaching experience in external LLMs

## Changes

### Prompt overhaul (`src/lib/prompts.ts`)
- Replaced the generic Socratic-method prompt with a structured multi-step coaching flow
- Step 0: check for resume; Step 1: generate 4 dream job scenarios and have the user pick one; Step 2: build a plan collaboratively
- Includes a "dinner party" framing to help users envision their ideal future

### Chat view cleanup (`src/app/chat/page.tsx`)
- Removed the rankings sidebar — the conversation now fills the page (max-w-3xl)

### Copy prompt unification (`src/lib/export.ts`)
- `buildCopyablePrompt` now delegates to `buildChatSystemPrompt` instead of maintaining a separate prompt
- Also passes resume text through, which the old version did not

### Copy updates
- **Landing page** (`src/app/page.tsx`): updated subtitle to genie theme; added hint about .md upload for session resume
- **Next steps page** (`src/app/next-steps/page.tsx`): "Your Genie Awaits" heading, simplified subtitle, updated coaching description

## Test plan

- [ ] Complete the full flow (questions + ranking) and verify the next-steps page copy
- [ ] Start an in-app chat and confirm the new prompt drives the dinner-party scenario flow
- [ ] Use "Copy Prompt" and paste into an external LLM — verify it matches the in-app experience
- [ ] Verify chat view has no rankings sidebar and conversation is centered
- [ ] Check landing page subtitle and resume session hint render correctly
