### PR TITLE
Chat toolbar tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Very loosely based on [Graham Weaver](https://www.grahamweaver.com/blog/the-comm
 
 No API key is needed until you opt into the in-app chat. When you do, your key is sent directly from the browser to the AI provider and never touches our servers. All resume parsing also happens client-side.
 
+**Your data stays on your device.** No user-inputted data — answers, rankings, resume content, or API keys — is ever stored or logged server-side. Everything runs entirely in your browser.
+
 ## Tech Stack
 
 Next.js 16 · React 19 · TypeScript · Tailwind CSS 4 · Vitest · Vercel

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -7,42 +7,100 @@ import { sendMessage } from '@/lib/llm-client';
 import { buildChatSystemPrompt } from '@/lib/prompts';
 import { ChatMessage } from '@/components/ChatMessage';
 import { ChatInput } from '@/components/ChatInput';
-
+import { ChatToolbar } from '@/components/ChatToolbar';
+import { ChatPanel } from '@/components/ChatPanel';
+import { AnswersPanel } from '@/components/AnswersPanel';
+import { RankingsPanel } from '@/components/RankingsPanel';
+import { ResumePanel } from '@/components/ResumePanel';
+import { CHAT_TOOLS, executeToolCall } from '@/lib/chat-tools';
+import { buildExportMarkdown, downloadTextFile } from '@/lib/export';
+import type { ChatMessage as ChatMessageType, ToolCall } from '@/types';
 
 export default function ChatPage() {
   const { state, dispatch } = useSession();
   const router = useRouter();
   const [streaming, setStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
+  const [activePanel, setActivePanel] = useState<'answers' | 'rankings' | 'resume' | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const initializedRef = useRef(false);
 
-  const systemPrompt = buildChatSystemPrompt(state.questionResponses, state.rankingState.sortedResult || [], state.resumeText);
+  const systemPrompt = buildChatSystemPrompt(
+    state.questionResponses,
+    state.rankingState.sortedResult || [],
+    state.resumeText,
+  );
 
-  async function generateInitialAdvice() {
+  const MAX_TOOL_ROUNDS = 3;
+
+  async function runChatTurn(messages: ChatMessageType[]) {
     setStreaming(true);
-    let content = '';
+    let currentRankings = state.rankingState.sortedResult || [];
+    let currentSystemPrompt = systemPrompt;
+    let currentMessages = messages;
 
     try {
-      for await (const chunk of sendMessage({
-        provider: state.provider,
-        apiKey: state.apiKey,
-        systemPrompt,
-        messages: [],
-      })) {
-        content += chunk;
-        setStreamingContent(content);
-      }
+      for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
+        let content = '';
+        const toolCalls: ToolCall[] = [];
 
-      dispatch({
-        type: 'ADD_CHAT_MESSAGE',
-        message: { role: 'assistant', content },
-      });
+        for await (const event of sendMessage({
+          provider: state.provider,
+          apiKey: state.apiKey,
+          systemPrompt: currentSystemPrompt,
+          messages: currentMessages,
+          tools: CHAT_TOOLS,
+        })) {
+          if (event.type === 'text') {
+            content += event.text;
+            setStreamingContent(content);
+          } else if (event.type === 'tool_call') {
+            toolCalls.push(event);
+          }
+        }
+
+        if (toolCalls.length === 0) {
+          dispatch({ type: 'ADD_CHAT_MESSAGE', message: { role: 'assistant', content } });
+          break;
+        }
+
+        const assistantMsg: ChatMessageType = { role: 'assistant', content, toolCalls };
+        dispatch({ type: 'ADD_CHAT_MESSAGE', message: assistantMsg });
+
+        const toolResultMessages: ChatMessageType[] = [];
+        for (const tc of toolCalls) {
+          const result = executeToolCall(tc, currentRankings);
+          if (result.newRankings) {
+            dispatch({
+              type: 'SET_RANKING_STATE',
+              rankingState: { sortedResult: result.newRankings },
+            });
+            currentRankings = result.newRankings;
+          }
+          toolResultMessages.push({
+            role: 'user',
+            content: result.resultText,
+            toolResult: { toolUseId: tc.id },
+          });
+        }
+
+        for (const trm of toolResultMessages) {
+          dispatch({ type: 'ADD_CHAT_MESSAGE', message: trm });
+        }
+
+        currentSystemPrompt = buildChatSystemPrompt(
+          state.questionResponses,
+          currentRankings,
+          state.resumeText,
+        );
+        currentMessages = [...currentMessages, assistantMsg, ...toolResultMessages];
+        setStreamingContent('');
+      }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Something went wrong';
       dispatch({
         type: 'ADD_CHAT_MESSAGE',
-        message: { role: 'assistant', content: `Error generating advice: ${errorMsg}` },
+        message: { role: 'assistant', content: `Error: ${errorMsg}` },
       });
     } finally {
       setStreaming(false);
@@ -58,7 +116,7 @@ export default function ChatPage() {
 
     if (!initializedRef.current && state.chatMessages.length === 0) {
       initializedRef.current = true;
-      generateInitialAdvice();
+      runChatTurn([]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -68,48 +126,35 @@ export default function ChatPage() {
   }, [state.chatMessages, streamingContent]);
 
   async function handleSend(text: string) {
-    const userMessage = { role: 'user' as const, content: text };
+    const userMessage: ChatMessageType = { role: 'user', content: text };
     dispatch({ type: 'ADD_CHAT_MESSAGE', message: userMessage });
+    runChatTurn([...state.chatMessages, userMessage]);
+  }
 
-    const allMessages = [...state.chatMessages, userMessage];
-    setStreaming(true);
-    let content = '';
+  function handleDownload() {
+    const md = buildExportMarkdown(
+      state.questionResponses,
+      state.rankingState.sortedResult,
+      state.resumeText,
+    );
+    if (md) downloadTextFile(md, 'career-genie-results.md');
+  }
 
-    try {
-      for await (const chunk of sendMessage({
-        provider: state.provider,
-        apiKey: state.apiKey,
-        systemPrompt,
-        messages: allMessages,
-      })) {
-        content += chunk;
-        setStreamingContent(content);
-      }
-
-      dispatch({
-        type: 'ADD_CHAT_MESSAGE',
-        message: { role: 'assistant', content },
-      });
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : 'Something went wrong';
-      dispatch({
-        type: 'ADD_CHAT_MESSAGE',
-        message: { role: 'assistant', content: `Error: ${errorMsg}` },
-      });
-    } finally {
-      setStreaming(false);
-      setStreamingContent('');
-    }
+  function handleReorderRankings(newRankings: string[]) {
+    dispatch({ type: 'SET_RANKING_STATE', rankingState: { sortedResult: newRankings } });
   }
 
   return (
     <main className="min-h-screen flex flex-col">
-
       <div className="flex-1 flex flex-col max-w-4xl mx-auto w-full px-4 py-4">
+        <ChatToolbar onOpenPanel={setActivePanel} onDownload={handleDownload} />
+
         <div className="flex-1 overflow-y-auto space-y-1">
-          {state.chatMessages.map((msg, i) => (
-            <ChatMessage key={i} message={msg} />
-          ))}
+          {state.chatMessages
+            .filter((msg) => !msg.toolResult)
+            .map((msg, i) => (
+              <ChatMessage key={i} message={msg} />
+            ))}
           {streaming && streamingContent && (
             <ChatMessage message={{ role: 'assistant', content: streamingContent }} />
           )}
@@ -124,6 +169,33 @@ export default function ChatPage() {
           />
         </div>
       </div>
+
+      <ChatPanel
+        title="Survey Answers"
+        open={activePanel === 'answers'}
+        onClose={() => setActivePanel(null)}
+      >
+        <AnswersPanel questionResponses={state.questionResponses} />
+      </ChatPanel>
+
+      <ChatPanel
+        title="Rankings"
+        open={activePanel === 'rankings'}
+        onClose={() => setActivePanel(null)}
+      >
+        <RankingsPanel
+          rankings={state.rankingState.sortedResult || []}
+          onReorder={handleReorderRankings}
+        />
+      </ChatPanel>
+
+      <ChatPanel
+        title="Resume"
+        open={activePanel === 'resume'}
+        onClose={() => setActivePanel(null)}
+      >
+        <ResumePanel resumeText={state.resumeText} />
+      </ChatPanel>
     </main>
   );
 }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -190,7 +190,7 @@ export default function ChatPage() {
       >
         <RankingsPanel
           rankings={state.rankingState.sortedResult || []}
-          onReorder={handleReorderRankings}
+          onSave={handleReorderRankings}
         />
       </ChatPanel>
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -142,6 +142,11 @@ export default function ChatPage() {
 
   function handleReorderRankings(newRankings: string[]) {
     dispatch({ type: 'SET_RANKING_STATE', rankingState: { sortedResult: newRankings } });
+    const rankingsList = newRankings.map((r, i) => `${i + 1}. ${r}`).join('\n');
+    dispatch({
+      type: 'ADD_CHAT_MESSAGE',
+      message: { role: 'user', content: `I've updated my rankings. New order:\n${rankingsList}` },
+    });
   }
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,6 +70,9 @@ export default function WelcomePage() {
               priorities, and upload your resume. Then start an open-ended
               coaching session in this app or in your AI Chat app of choice.
             </p>
+            <p className="text-sm text-stone-400">
+              Your data never leaves your browser — nothing is stored or logged on our servers.
+            </p>
             <button
               onClick={handleStart}
               className="w-full rounded-xl bg-emerald-500 py-3 text-sm font-medium text-white hover:bg-emerald-600 transition-colors"

--- a/src/components/AnswersPanel.tsx
+++ b/src/components/AnswersPanel.tsx
@@ -1,0 +1,29 @@
+import type { QuestionResponse } from '@/types';
+
+interface AnswersPanelProps {
+  questionResponses: QuestionResponse[];
+}
+
+export function AnswersPanel({ questionResponses }: AnswersPanelProps) {
+  const answered = questionResponses.filter((qr) => qr.answer.trim());
+
+  if (answered.length === 0) {
+    return <p className="text-sm text-stone-500">No answers recorded.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {answered.map((qr) => (
+        <div key={qr.questionId} className="border-b border-stone-200 pb-3 last:border-0">
+          <p className="text-sm font-medium text-stone-700">{qr.question}</p>
+          <p className="text-sm text-stone-900 mt-1">{qr.answer}</p>
+          {qr.whyAnswer.trim() && (
+            <p className="text-sm text-stone-500 mt-1">
+              <span className="font-medium">Why:</span> {qr.whyAnswer}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -2,6 +2,8 @@ import type { ChatMessage as ChatMessageType } from '@/types';
 import ReactMarkdown from 'react-markdown';
 
 export function ChatMessage({ message }: { message: ChatMessageType }) {
+  if (message.toolResult) return null;
+
   const isUser = message.role === 'user';
 
   return (

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface ChatPanelProps {
+  title: string;
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export function ChatPanel({ title, open, onClose, children }: ChatPanelProps) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/20 z-40" onClick={onClose} />
+      <div className="fixed top-0 right-0 h-full w-96 max-w-[90vw] bg-stone-50 shadow-xl z-50 flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-stone-200">
+          <h2 className="font-semibold text-stone-900">{title}</h2>
+          <button
+            onClick={onClose}
+            className="text-stone-400 hover:text-stone-600 text-xl leading-none"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ChatToolbar.tsx
+++ b/src/components/ChatToolbar.tsx
@@ -16,7 +16,7 @@ const BUTTONS: { panel?: PanelType; label: string; action?: 'download' }[] = [
 
 export function ChatToolbar({ onOpenPanel, onDownload }: ChatToolbarProps) {
   return (
-    <div className="flex gap-2 py-2 border-b border-stone-200 mb-2">
+    <div className="sticky top-0 z-10 flex gap-2 py-2 border-b border-stone-200 mb-2 bg-stone-50">
       {BUTTONS.map((btn) => (
         <button
           key={btn.label}

--- a/src/components/ChatToolbar.tsx
+++ b/src/components/ChatToolbar.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+type PanelType = 'answers' | 'rankings' | 'resume';
+
+interface ChatToolbarProps {
+  onOpenPanel: (panel: PanelType) => void;
+  onDownload: () => void;
+}
+
+const BUTTONS: { panel?: PanelType; label: string; action?: 'download' }[] = [
+  { panel: 'answers', label: 'Answers' },
+  { panel: 'rankings', label: 'Rankings' },
+  { panel: 'resume', label: 'Resume' },
+  { label: 'Download .md', action: 'download' },
+];
+
+export function ChatToolbar({ onOpenPanel, onDownload }: ChatToolbarProps) {
+  return (
+    <div className="flex gap-2 py-2 border-b border-stone-200 mb-2">
+      {BUTTONS.map((btn) => (
+        <button
+          key={btn.label}
+          onClick={() => (btn.action === 'download' ? onDownload() : onOpenPanel(btn.panel!))}
+          className="px-3 py-1.5 text-xs font-medium rounded-lg border border-stone-300 text-stone-600 hover:bg-stone-100 hover:text-stone-800 transition-colors"
+        >
+          {btn.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/RankingsPanel.tsx
+++ b/src/components/RankingsPanel.tsx
@@ -1,16 +1,26 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+
 interface RankingsPanelProps {
   rankings: string[];
-  onReorder: (newRankings: string[]) => void;
+  onSave: (newRankings: string[]) => void;
 }
 
-export function RankingsPanel({ rankings, onReorder }: RankingsPanelProps) {
+export function RankingsPanel({ rankings, onSave }: RankingsPanelProps) {
+  const [draft, setDraft] = useState(rankings);
+
+  useEffect(() => {
+    setDraft(rankings);
+  }, [rankings]);
+
+  const hasChanges = JSON.stringify(draft) !== JSON.stringify(rankings);
+
   function moveItem(index: number, direction: 'up' | 'down') {
-    const newRankings = [...rankings];
+    const next = [...draft];
     const swapIndex = direction === 'up' ? index - 1 : index + 1;
-    [newRankings[index], newRankings[swapIndex]] = [newRankings[swapIndex], newRankings[index]];
-    onReorder(newRankings);
+    [next[index], next[swapIndex]] = [next[swapIndex], next[index]];
+    setDraft(next);
   }
 
   if (rankings.length === 0) {
@@ -19,7 +29,7 @@ export function RankingsPanel({ rankings, onReorder }: RankingsPanelProps) {
 
   return (
     <div className="space-y-1">
-      {rankings.map((item, i) => (
+      {draft.map((item, i) => (
         <div
           key={item}
           className="flex items-center gap-2 py-2 px-3 rounded-lg bg-white border border-stone-200"
@@ -36,7 +46,7 @@ export function RankingsPanel({ rankings, onReorder }: RankingsPanelProps) {
           </button>
           <button
             onClick={() => moveItem(i, 'down')}
-            disabled={i === rankings.length - 1}
+            disabled={i === draft.length - 1}
             className="text-stone-400 hover:text-stone-700 disabled:opacity-25 disabled:hover:text-stone-400 text-sm px-1"
             aria-label={`Move ${item} down`}
           >
@@ -44,6 +54,14 @@ export function RankingsPanel({ rankings, onReorder }: RankingsPanelProps) {
           </button>
         </div>
       ))}
+      {hasChanges && (
+        <button
+          onClick={() => onSave(draft)}
+          className="mt-3 w-full py-2 text-sm font-medium rounded-lg bg-stone-800 text-white hover:bg-stone-700 transition-colors"
+        >
+          Save Rankings
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/RankingsPanel.tsx
+++ b/src/components/RankingsPanel.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+interface RankingsPanelProps {
+  rankings: string[];
+  onReorder: (newRankings: string[]) => void;
+}
+
+export function RankingsPanel({ rankings, onReorder }: RankingsPanelProps) {
+  function moveItem(index: number, direction: 'up' | 'down') {
+    const newRankings = [...rankings];
+    const swapIndex = direction === 'up' ? index - 1 : index + 1;
+    [newRankings[index], newRankings[swapIndex]] = [newRankings[swapIndex], newRankings[index]];
+    onReorder(newRankings);
+  }
+
+  if (rankings.length === 0) {
+    return <p className="text-sm text-stone-500">No rankings recorded.</p>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {rankings.map((item, i) => (
+        <div
+          key={item}
+          className="flex items-center gap-2 py-2 px-3 rounded-lg bg-white border border-stone-200"
+        >
+          <span className="text-stone-400 text-sm w-6 text-right shrink-0">{i + 1}.</span>
+          <span className="flex-1 text-sm text-stone-900">{item}</span>
+          <button
+            onClick={() => moveItem(i, 'up')}
+            disabled={i === 0}
+            className="text-stone-400 hover:text-stone-700 disabled:opacity-25 disabled:hover:text-stone-400 text-sm px-1"
+            aria-label={`Move ${item} up`}
+          >
+            &#9650;
+          </button>
+          <button
+            onClick={() => moveItem(i, 'down')}
+            disabled={i === rankings.length - 1}
+            className="text-stone-400 hover:text-stone-700 disabled:opacity-25 disabled:hover:text-stone-400 text-sm px-1"
+            aria-label={`Move ${item} down`}
+          >
+            &#9660;
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ResumePanel.tsx
+++ b/src/components/ResumePanel.tsx
@@ -1,0 +1,15 @@
+interface ResumePanelProps {
+  resumeText: string;
+}
+
+export function ResumePanel({ resumeText }: ResumePanelProps) {
+  if (!resumeText.trim()) {
+    return <p className="text-sm text-stone-500">No resume uploaded.</p>;
+  }
+
+  return (
+    <div className="prose prose-sm prose-stone max-w-none">
+      <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans">{resumeText}</pre>
+    </div>
+  );
+}

--- a/src/components/ResumePanel.tsx
+++ b/src/components/ResumePanel.tsx
@@ -8,8 +8,6 @@ export function ResumePanel({ resumeText }: ResumePanelProps) {
   }
 
   return (
-    <div className="prose prose-sm prose-stone max-w-none">
-      <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans">{resumeText}</pre>
-    </div>
+    <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans leading-relaxed">{resumeText}</pre>
   );
 }

--- a/src/lib/__tests__/chat-tools.test.ts
+++ b/src/lib/__tests__/chat-tools.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { executeUpdateRankings, CHAT_TOOLS } from '../chat-tools';
+
+const SAMPLE_ITEMS = [
+  'High base compensation',
+  'Work-life balance / flexible hours',
+  'Remote work options',
+];
+
+describe('CHAT_TOOLS', () => {
+  it('exports update_rankings tool definition', () => {
+    expect(CHAT_TOOLS).toHaveLength(1);
+    expect(CHAT_TOOLS[0].name).toBe('update_rankings');
+    expect(CHAT_TOOLS[0].inputSchema).toBeDefined();
+  });
+});
+
+describe('executeUpdateRankings', () => {
+  it('reorders rankings successfully', () => {
+    const result = executeUpdateRankings(
+      { rankings: ['Remote work options', 'High base compensation', 'Work-life balance / flexible hours'] },
+      SAMPLE_ITEMS,
+    );
+    expect(result.success).toBe(true);
+    expect(result.newRankings).toEqual([
+      'Remote work options',
+      'High base compensation',
+      'Work-life balance / flexible hours',
+    ]);
+    expect(result.resultText).toContain('Rankings updated successfully');
+  });
+
+  it('rejects non-array input', () => {
+    const result = executeUpdateRankings({ rankings: 'not an array' }, SAMPLE_ITEMS);
+    expect(result.success).toBe(false);
+    expect(result.resultText).toContain('must be an array');
+  });
+
+  it('rejects wrong number of items', () => {
+    const result = executeUpdateRankings({ rankings: ['Only one'] }, SAMPLE_ITEMS);
+    expect(result.success).toBe(false);
+    expect(result.resultText).toContain('expected 3 items');
+  });
+
+  it('rejects unknown items', () => {
+    const result = executeUpdateRankings(
+      { rankings: ['Unknown item', 'High base compensation', 'Remote work options'] },
+      SAMPLE_ITEMS,
+    );
+    expect(result.success).toBe(false);
+    expect(result.resultText).toContain('not a valid career quality');
+  });
+
+  it('rejects duplicate items', () => {
+    const result = executeUpdateRankings(
+      { rankings: ['Remote work options', 'Remote work options', 'High base compensation'] },
+      SAMPLE_ITEMS,
+    );
+    expect(result.success).toBe(false);
+    expect(result.resultText).toContain('duplicate');
+  });
+
+  it('matches items case-insensitively and preserves original casing', () => {
+    const result = executeUpdateRankings(
+      { rankings: ['remote work options', 'high base compensation', 'work-life balance / flexible hours'] },
+      SAMPLE_ITEMS,
+    );
+    expect(result.success).toBe(true);
+    expect(result.newRankings).toEqual([
+      'Remote work options',
+      'High base compensation',
+      'Work-life balance / flexible hours',
+    ]);
+  });
+});

--- a/src/lib/__tests__/llm-client.test.ts
+++ b/src/lib/__tests__/llm-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { parseAnthropicStream, parseOpenAIStream, sendMessage, validateApiKey } from '../llm-client';
+import { parseAnthropicStream, parseOpenAIStream, sendMessage, validateApiKey, toAnthropicMessages, toOpenAIMessages } from '../llm-client';
 
 function makeStream(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -174,5 +174,90 @@ describe('validateApiKey', () => {
     await expect(validateApiKey('anthropic', 'bad-key')).rejects.toThrow(
       'Invalid API key. Please check your key and try again.',
     );
+  });
+});
+
+describe('toAnthropicMessages', () => {
+  it('passes plain text messages through', () => {
+    const messages = [
+      { role: 'user' as const, content: 'Hello' },
+      { role: 'assistant' as const, content: 'Hi there' },
+    ];
+    expect(toAnthropicMessages(messages)).toEqual([
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ]);
+  });
+
+  it('converts assistant message with toolCalls to content blocks', () => {
+    const messages = [{
+      role: 'assistant' as const,
+      content: 'Updating rankings...',
+      toolCalls: [{ id: 'toolu_123', name: 'update_rankings', input: { rankings: ['A', 'B'] } }],
+    }];
+    const result = toAnthropicMessages(messages);
+    expect(result).toEqual([{
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Updating rankings...' },
+        { type: 'tool_use', id: 'toolu_123', name: 'update_rankings', input: { rankings: ['A', 'B'] } },
+      ],
+    }]);
+  });
+
+  it('converts toolResult message to tool_result content block', () => {
+    const messages = [{
+      role: 'user' as const,
+      content: 'Rankings updated successfully.',
+      toolResult: { toolUseId: 'toolu_123' },
+    }];
+    const result = toAnthropicMessages(messages);
+    expect(result).toEqual([{
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'toolu_123', content: 'Rankings updated successfully.' }],
+    }]);
+  });
+});
+
+describe('toOpenAIMessages', () => {
+  it('includes system prompt and passes plain messages through', () => {
+    const messages = [{ role: 'user' as const, content: 'Hello' }];
+    const result = toOpenAIMessages(messages, 'Be helpful');
+    expect(result).toEqual([
+      { role: 'system', content: 'Be helpful' },
+      { role: 'user', content: 'Hello' },
+    ]);
+  });
+
+  it('converts assistant message with toolCalls to OpenAI format', () => {
+    const messages = [{
+      role: 'assistant' as const,
+      content: 'Updating...',
+      toolCalls: [{ id: 'call_abc', name: 'update_rankings', input: { rankings: ['A'] } }],
+    }];
+    const result = toOpenAIMessages(messages, 'sys');
+    expect(result[1]).toEqual({
+      role: 'assistant',
+      content: 'Updating...',
+      tool_calls: [{
+        id: 'call_abc',
+        type: 'function',
+        function: { name: 'update_rankings', arguments: '{"rankings":["A"]}' },
+      }],
+    });
+  });
+
+  it('converts toolResult message to OpenAI tool role', () => {
+    const messages = [{
+      role: 'user' as const,
+      content: 'Done.',
+      toolResult: { toolUseId: 'call_abc' },
+    }];
+    const result = toOpenAIMessages(messages, 'sys');
+    expect(result[1]).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_abc',
+      content: 'Done.',
+    });
   });
 });

--- a/src/lib/__tests__/llm-client.test.ts
+++ b/src/lib/__tests__/llm-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { StreamEvent } from '@/types';
 import { parseAnthropicStream, parseOpenAIStream, sendMessage, validateApiKey, toAnthropicMessages, toOpenAIMessages } from '../llm-client';
 
 function makeStream(chunks: string[]): ReadableStream<Uint8Array> {
@@ -21,12 +22,40 @@ describe('parseAnthropicStream', () => {
       'event: message_stop\ndata: {"type":"message_stop"}\n\n',
     ]);
 
-    const chunks: string[] = [];
-    for await (const chunk of parseAnthropicStream(stream)) {
-      chunks.push(chunk);
+    const events: StreamEvent[] = [];
+    for await (const event of parseAnthropicStream(stream)) {
+      events.push(event);
     }
 
-    expect(chunks).toEqual(['Hello', ' world']);
+    expect(events).toEqual([
+      { type: 'text', text: 'Hello' },
+      { type: 'text', text: ' world' },
+    ]);
+  });
+});
+
+describe('parseAnthropicStream — tool calls', () => {
+  it('yields tool_call event from streamed tool_use blocks', async () => {
+    const stream = makeStream([
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Updating..."}}\n\n',
+      'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_123","name":"update_rankings","input":{}}}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"rankings\\""}}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":": [\\"A\\", \\"B\\"]}"}}\n\n',
+      'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]);
+
+    const events: StreamEvent[] = [];
+    for await (const event of parseAnthropicStream(stream)) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: 'text', text: 'Updating...' },
+      { type: 'tool_call', id: 'toolu_123', name: 'update_rankings', input: { rankings: ['A', 'B'] } },
+    ]);
   });
 });
 
@@ -38,12 +67,38 @@ describe('parseOpenAIStream', () => {
       'data: [DONE]\n\n',
     ]);
 
-    const chunks: string[] = [];
-    for await (const chunk of parseOpenAIStream(stream)) {
-      chunks.push(chunk);
+    const events: StreamEvent[] = [];
+    for await (const event of parseOpenAIStream(stream)) {
+      events.push(event);
     }
 
-    expect(chunks).toEqual(['Hello', ' world']);
+    expect(events).toEqual([
+      { type: 'text', text: 'Hello' },
+      { type: 'text', text: ' world' },
+    ]);
+  });
+});
+
+describe('parseOpenAIStream — tool calls', () => {
+  it('yields tool_call event from streamed tool_calls', async () => {
+    const stream = makeStream([
+      'data: {"choices":[{"delta":{"content":"Updating..."}}]}\n\n',
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"update_rankings","arguments":""}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"rankings\\""}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":": [\\"A\\", \\"B\\"]}"}}]}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+
+    const events: StreamEvent[] = [];
+    for await (const event of parseOpenAIStream(stream)) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      { type: 'text', text: 'Updating...' },
+      { type: 'tool_call', id: 'call_abc', name: 'update_rankings', input: { rankings: ['A', 'B'] } },
+    ]);
   });
 });
 
@@ -65,17 +120,17 @@ describe('sendMessage', () => {
     ]);
     fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
 
-    const chunks: string[] = [];
-    for await (const chunk of sendMessage({
+    const events: StreamEvent[] = [];
+    for await (const event of sendMessage({
       provider: 'anthropic',
       apiKey: 'sk-ant-test',
       systemPrompt: 'Be helpful',
       messages: [{ role: 'user', content: 'Hello' }],
     })) {
-      chunks.push(chunk);
+      events.push(event);
     }
 
-    expect(chunks).toEqual(['Hi']);
+    expect(events).toEqual([{ type: 'text', text: 'Hi' }]);
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.anthropic.com/v1/messages',
       expect.objectContaining({
@@ -99,17 +154,17 @@ describe('sendMessage', () => {
     ]);
     fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
 
-    const chunks: string[] = [];
-    for await (const chunk of sendMessage({
+    const events: StreamEvent[] = [];
+    for await (const event of sendMessage({
       provider: 'openai',
       apiKey: 'sk-test',
       systemPrompt: 'Be helpful',
       messages: [{ role: 'user', content: 'Hello' }],
     })) {
-      chunks.push(chunk);
+      events.push(event);
     }
 
-    expect(chunks).toEqual(['Hi']);
+    expect(events).toEqual([{ type: 'text', text: 'Hi' }]);
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.openai.com/v1/chat/completions',
       expect.objectContaining({ method: 'POST' }),

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -4,6 +4,8 @@ export const UPDATE_RANKINGS_TOOL: ToolDefinition = {
   name: 'update_rankings',
   description:
     'Update the user\'s priority rankings. Provide the complete list of qualities in the new desired order, from most important (first) to least important (last). All existing qualities must be included.',
+  // TODO: Use an enum in items to restrict values to the user's actual ranking attributes.
+  // This would let provider structured outputs reject invalid items at the API level.
   inputSchema: {
     type: 'object',
     properties: {

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -1,0 +1,73 @@
+import type { ToolDefinition, ToolCall } from '@/types';
+
+export const UPDATE_RANKINGS_TOOL: ToolDefinition = {
+  name: 'update_rankings',
+  description:
+    'Update the user\'s priority rankings. Provide the complete list of qualities in the new desired order, from most important (first) to least important (last). All existing qualities must be included.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      rankings: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Complete ordered list of career qualities, most important first. Must contain all qualities.',
+      },
+    },
+    required: ['rankings'],
+  },
+};
+
+export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL];
+
+export function executeUpdateRankings(
+  input: Record<string, unknown>,
+  currentItems: string[],
+): { success: boolean; resultText: string; newRankings?: string[] } {
+  const rankings = input.rankings;
+
+  if (!Array.isArray(rankings)) {
+    return { success: false, resultText: 'Error: rankings must be an array.' };
+  }
+
+  if (rankings.length !== currentItems.length) {
+    return {
+      success: false,
+      resultText: `Error: expected ${currentItems.length} items, got ${rankings.length}.`,
+    };
+  }
+
+  const itemMap = new Map(currentItems.map((i) => [i.toLowerCase(), i]));
+  const normalizedNew = rankings.map((r: string) => r.toLowerCase());
+
+  for (const item of normalizedNew) {
+    if (!itemMap.has(item)) {
+      return { success: false, resultText: `Error: "${item}" is not a valid career quality.` };
+    }
+  }
+
+  if (new Set(normalizedNew).size !== normalizedNew.length) {
+    return { success: false, resultText: 'Error: duplicate items in rankings.' };
+  }
+
+  const newRankings = normalizedNew.map((n) => itemMap.get(n)!);
+  const resultText =
+    'Rankings updated successfully. New order:\n' +
+    newRankings.map((r, i) => `${i + 1}. ${r}`).join('\n');
+
+  return { success: true, resultText, newRankings };
+}
+
+export function executeToolCall(
+  toolCall: ToolCall,
+  currentRankings: string[],
+): { resultText: string; newRankings?: string[] } {
+  if (toolCall.name === 'update_rankings') {
+    const result = executeUpdateRankings(toolCall.input, currentRankings);
+    return {
+      resultText: result.resultText,
+      newRankings: result.success ? result.newRankings : undefined,
+    };
+  }
+  return { resultText: `Error: unknown tool "${toolCall.name}".` };
+}

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -1,10 +1,11 @@
-import type { Provider, ChatMessage } from '@/types';
+import type { Provider, ChatMessage, ToolDefinition, StreamEvent } from '@/types';
 
 interface SendMessageParams {
   provider: Provider;
   apiKey: string;
   systemPrompt: string;
   messages: ChatMessage[];
+  tools?: ToolDefinition[];
 }
 
 function buildProviderRequest(
@@ -88,19 +89,40 @@ export function toOpenAIMessages(messages: ChatMessage[], systemPrompt: string):
 
 export async function* sendMessage(
   params: SendMessageParams,
-): AsyncGenerator<string> {
-  const { provider, apiKey, systemPrompt, messages } = params;
+): AsyncGenerator<StreamEvent> {
+  const { provider, apiKey, systemPrompt, messages, tools } = params;
 
-  const effectiveMessages = messages.length === 0
+  const effectiveMessages: ChatMessage[] = messages.length === 0
     ? [{ role: 'user' as const, content: 'Begin the coaching session' }]
     : messages[0].role !== 'user'
       ? [{ role: 'user' as const, content: 'Begin the coaching session' }, ...messages]
       : messages;
 
+  const anthropicTools = tools?.length
+    ? tools.map((t) => ({ name: t.name, description: t.description, input_schema: t.inputSchema }))
+    : undefined;
+
+  const openaiTools = tools?.length
+    ? tools.map((t) => ({ type: 'function', function: { name: t.name, description: t.description, parameters: t.inputSchema } }))
+    : undefined;
+
   const body =
     provider === 'anthropic'
-      ? { model: 'claude-sonnet-4-6', max_tokens: 1024, system: systemPrompt, messages: effectiveMessages, stream: true }
-      : { model: 'gpt-4o', messages: [{ role: 'system', content: systemPrompt }, ...effectiveMessages], max_tokens: 1024, stream: true };
+      ? {
+          model: 'claude-sonnet-4-6',
+          max_tokens: 1024,
+          system: systemPrompt,
+          messages: toAnthropicMessages(effectiveMessages),
+          stream: true,
+          ...(anthropicTools ? { tools: anthropicTools } : {}),
+        }
+      : {
+          model: 'gpt-4o',
+          messages: toOpenAIMessages(effectiveMessages, systemPrompt),
+          max_tokens: 1024,
+          stream: true,
+          ...(openaiTools ? { tools: openaiTools } : {}),
+        };
 
   const { url, init } = buildProviderRequest(provider, apiKey, body);
   const response = await fetch(url, init);
@@ -134,10 +156,11 @@ export async function validateApiKey(provider: Provider, apiKey: string): Promis
 
 export async function* parseAnthropicStream(
   body: ReadableStream<Uint8Array>,
-): AsyncGenerator<string> {
+): AsyncGenerator<StreamEvent> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  let pendingToolCall: { id: string; name: string; jsonChunks: string[] } | null = null;
 
   try {
     while (true) {
@@ -153,11 +176,28 @@ export async function* parseAnthropicStream(
         const data = line.slice(6);
         try {
           const parsed = JSON.parse(data);
-          if (
-            parsed.type === 'content_block_delta' &&
-            parsed.delta?.type === 'text_delta'
-          ) {
-            yield parsed.delta.text;
+
+          if (parsed.type === 'content_block_start' && parsed.content_block?.type === 'tool_use') {
+            pendingToolCall = {
+              id: parsed.content_block.id,
+              name: parsed.content_block.name,
+              jsonChunks: [],
+            };
+          } else if (parsed.type === 'content_block_delta') {
+            if (parsed.delta?.type === 'text_delta') {
+              yield { type: 'text', text: parsed.delta.text };
+            } else if (parsed.delta?.type === 'input_json_delta' && pendingToolCall) {
+              pendingToolCall.jsonChunks.push(parsed.delta.partial_json);
+            }
+          } else if (parsed.type === 'content_block_stop' && pendingToolCall) {
+            const input = JSON.parse(pendingToolCall.jsonChunks.join(''));
+            yield {
+              type: 'tool_call',
+              id: pendingToolCall.id,
+              name: pendingToolCall.name,
+              input,
+            };
+            pendingToolCall = null;
           }
         } catch {
           // skip non-JSON lines
@@ -171,10 +211,11 @@ export async function* parseAnthropicStream(
 
 export async function* parseOpenAIStream(
   body: ReadableStream<Uint8Array>,
-): AsyncGenerator<string> {
+): AsyncGenerator<StreamEvent> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  const pendingToolCalls = new Map<number, { id: string; name: string; argChunks: string[] }>();
 
   try {
     while (true) {
@@ -192,7 +233,30 @@ export async function* parseOpenAIStream(
         try {
           const parsed = JSON.parse(data);
           const content = parsed.choices?.[0]?.delta?.content;
-          if (content) yield content;
+          if (content) yield { type: 'text', text: content };
+
+          const toolCalls = parsed.choices?.[0]?.delta?.tool_calls;
+          if (toolCalls) {
+            for (const tc of toolCalls) {
+              const idx = tc.index ?? 0;
+              if (!pendingToolCalls.has(idx)) {
+                pendingToolCalls.set(idx, { id: '', name: '', argChunks: [] });
+              }
+              const pending = pendingToolCalls.get(idx)!;
+              if (tc.id) pending.id = tc.id;
+              if (tc.function?.name) pending.name = tc.function.name;
+              if (tc.function?.arguments) pending.argChunks.push(tc.function.arguments);
+            }
+          }
+
+          const finishReason = parsed.choices?.[0]?.finish_reason;
+          if (finishReason === 'tool_calls') {
+            for (const tc of pendingToolCalls.values()) {
+              const input = JSON.parse(tc.argChunks.join(''));
+              yield { type: 'tool_call', id: tc.id, name: tc.name, input };
+            }
+            pendingToolCalls.clear();
+          }
         } catch {
           // skip non-JSON lines
         }

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -40,6 +40,52 @@ function buildProviderRequest(
   };
 }
 
+export function toAnthropicMessages(messages: ChatMessage[]): unknown[] {
+  return messages.map((m) => {
+    if (m.toolCalls && m.toolCalls.length > 0) {
+      const content: unknown[] = [];
+      if (m.content) content.push({ type: 'text', text: m.content });
+      for (const tc of m.toolCalls) {
+        content.push({ type: 'tool_use', id: tc.id, name: tc.name, input: tc.input });
+      }
+      return { role: 'assistant', content };
+    }
+    if (m.toolResult) {
+      return {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: m.toolResult.toolUseId, content: m.content }],
+      };
+    }
+    return { role: m.role, content: m.content };
+  });
+}
+
+export function toOpenAIMessages(messages: ChatMessage[], systemPrompt: string): unknown[] {
+  const result: unknown[] = [{ role: 'system', content: systemPrompt }];
+  for (const m of messages) {
+    if (m.toolCalls && m.toolCalls.length > 0) {
+      result.push({
+        role: 'assistant',
+        content: m.content || null,
+        tool_calls: m.toolCalls.map((tc) => ({
+          id: tc.id,
+          type: 'function',
+          function: { name: tc.name, arguments: JSON.stringify(tc.input) },
+        })),
+      });
+    } else if (m.toolResult) {
+      result.push({
+        role: 'tool',
+        tool_call_id: m.toolResult.toolUseId,
+        content: m.content,
+      });
+    } else {
+      result.push({ role: m.role, content: m.content });
+    }
+  }
+  return result;
+}
+
 export async function* sendMessage(
   params: SendMessageParams,
 ): AsyncGenerator<string> {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -21,6 +21,14 @@ Sub-task details
   2b. Try to have the user create their own plan by answering your questions, but prompt them with suggestions if they get completely stuck
 </instructions>
 
+<tools_guidance>
+You have access to an update_rankings tool that can reorder the user's career quality priorities. Use it when:
+- The user explicitly asks to change their ranking order
+- The conversation reveals a clear shift in priorities that the user confirms
+
+Always confirm the intended change with the user before calling the tool. After using the tool, briefly acknowledge what changed.
+</tools_guidance>
+
 {{REFLECTION_ANSWERS}}
 
 {{RANKED_QUALITIES}}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,9 +2,27 @@ export type Provider = 'anthropic' | 'openai';
 
 export type WizardStep = 'setup' | 'hub' | 'questions' | 'rank' | 'resume' | 'next-steps' | 'chat';
 
+export interface ToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export type StreamEvent =
+  | { type: 'text'; text: string }
+  | { type: 'tool_call'; id: string; name: string; input: Record<string, unknown> };
+
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
+  toolCalls?: ToolCall[];
+  toolResult?: { toolUseId: string };
 }
 
 export interface QuestionResponse {


### PR DESCRIPTION
## Summary

- **Chat toolbar** with sticky top bar and slide-out panels for viewing survey answers, rankings, and resume without disrupting the chat
- **Native API tool calling** for both Anthropic and OpenAI providers — the LLM can update the user's career quality rankings via structured `update_rankings` tool calls
- **Editable rankings panel** with up/down reorder buttons and a Save button — edits are batched locally, and a single synthetic user message is injected into chat on save so the LLM sees the change
- **Download .md** button exports the full session (answers, rankings, resume) as a markdown file
- **Stream parser upgrades** — `parseAnthropicStream` and `parseOpenAIStream` now yield `StreamEvent` discriminated union (text or tool_call), with provider-specific message converters for tool_use/tool_result wire formats
- **Tool call loop** in the chat page (max 3 rounds) handles stream → execute tool → send result → stream confirmation, with local ranking tracking to avoid stale React state closures

## Changes

### New files
| File | Purpose |
|------|---------|
| `src/lib/chat-tools.ts` | Tool definitions, input validation (count, duplicates, case-insensitive matching), execution |
| `src/lib/__tests__/chat-tools.test.ts` | 7 tests covering tool validation edge cases |
| `src/components/ChatToolbar.tsx` | Sticky toolbar with Answers, Rankings, Resume, Download buttons |
| `src/components/ChatPanel.tsx` | Right-side slide-out drawer with backdrop overlay |
| `src/components/AnswersPanel.tsx` | Read-only survey answers display |
| `src/components/RankingsPanel.tsx` | Editable rankings list with up/down arrow buttons and Save button (local draft state) |
| `src/components/ResumePanel.tsx` | Read-only resume text display |

### Modified files
| File | Changes |
|------|---------|
| `src/types/index.ts` | Added `ToolCall`, `ToolDefinition`, `StreamEvent` types; extended `ChatMessage` with `toolCalls` and `toolResult` |
| `src/lib/llm-client.ts` | `sendMessage` accepts `tools` param, yields `StreamEvent`; added `toAnthropicMessages`/`toOpenAIMessages` converters; stream parsers handle tool_use/tool_calls |
| `src/lib/__tests__/llm-client.test.ts` | Updated for `StreamEvent`, added tool call parsing and message converter tests |
| `src/lib/prompts.ts` | Added `<tools_guidance>` section to chat system prompt |
| `src/app/chat/page.tsx` | Toolbar, panel state, tool call loop via shared `runChatTurn`, manual ranking edit notification |
| `src/components/ChatMessage.tsx` | Skip rendering `toolResult` messages |
| `README.md` | Added no-server-side-storage notice |
| `src/app/page.tsx` | Added no-server-side-storage notice on landing page |

## Test plan

- [ ] All 83 unit tests pass (`npm test`)
- [ ] Production build succeeds (`npm run build`)
- [ ] Toolbar buttons open/close slide-out panels correctly
- [ ] Rankings panel reorder buttons update draft locally; Save button appears on change and sends one chat message
- [ ] Resume panel displays uploaded resume text
- [ ] Download .md exports correct content
- [ ] LLM can call `update_rankings` tool during chat (ask it to reorder priorities)
- [ ] Tool call updates rankings in state and LLM confirms the change
- [ ] Works with both Anthropic and OpenAI providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
