### PR TITLE
feat: add chat toolbar, tool calls, and resume builder (#31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .superpowers/
 .vercel
+.env*.local
 
 .DS_Store
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -127,12 +127,16 @@ export default function ChatPage() {
     if (state.resumeText.trim() && !state.updatedResumeMarkdown) {
       try {
         let formatted = '';
+        const fastModel = state.provider === 'anthropic'
+          ? 'claude-haiku-4-5-20251001'
+          : 'gpt-5.4-mini';
         for await (const event of sendMessage({
           provider: state.provider,
           apiKey: state.apiKey,
           systemPrompt: RESUME_FORMATTING_SYSTEM_PROMPT,
           messages: [{ role: 'user' as const, content: state.resumeText }],
           maxTokens: 4096,
+          model: fastModel,
         })) {
           if (event.type === 'text') {
             formatted += event.text;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession, areAllStepsComplete } from '@/context/SessionContext';
 import { sendMessage } from '@/lib/llm-client';
-import { buildChatSystemPrompt } from '@/lib/prompts';
+import { buildChatSystemPrompt, RESUME_FORMATTING_SYSTEM_PROMPT } from '@/lib/prompts';
 import { ChatMessage } from '@/components/ChatMessage';
 import { ChatInput } from '@/components/ChatInput';
 import { ChatToolbar } from '@/components/ChatToolbar';
@@ -22,6 +22,7 @@ export default function ChatPage() {
   const [streaming, setStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
   const [activePanel, setActivePanel] = useState<'answers' | 'rankings' | 'resume' | null>(null);
+  const [resumeJustUpdated, setResumeJustUpdated] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const initializedRef = useRef(false);
 
@@ -29,6 +30,7 @@ export default function ChatPage() {
     state.questionResponses,
     state.rankingState.sortedResult || [],
     state.resumeText,
+    state.updatedResumeMarkdown,
   );
 
   const MAX_TOOL_ROUNDS = 3;
@@ -36,6 +38,7 @@ export default function ChatPage() {
   async function runChatTurn(messages: ChatMessageType[]) {
     setStreaming(true);
     let currentRankings = state.rankingState.sortedResult || [];
+    let currentUpdatedResume = state.updatedResumeMarkdown;
     let currentSystemPrompt = systemPrompt;
     let currentMessages = messages;
 
@@ -50,6 +53,7 @@ export default function ChatPage() {
           systemPrompt: currentSystemPrompt,
           messages: currentMessages,
           tools: CHAT_TOOLS,
+          maxTokens: 2048,
         })) {
           if (event.type === 'text') {
             content += event.text;
@@ -77,6 +81,14 @@ export default function ChatPage() {
             });
             currentRankings = result.newRankings;
           }
+          if (result.newResume) {
+            dispatch({
+              type: 'SET_UPDATED_RESUME_MARKDOWN',
+              updatedResumeMarkdown: result.newResume,
+            });
+            currentUpdatedResume = result.newResume;
+            setResumeJustUpdated(true);
+          }
           toolResultMessages.push({
             role: 'user',
             content: result.resultText,
@@ -92,6 +104,7 @@ export default function ChatPage() {
           state.questionResponses,
           currentRankings,
           state.resumeText,
+          currentUpdatedResume,
         );
         currentMessages = [...currentMessages, assistantMsg, ...toolResultMessages];
         setStreamingContent('');
@@ -108,6 +121,31 @@ export default function ChatPage() {
     }
   }
 
+  async function initializeChat() {
+    if (state.resumeText.trim() && !state.updatedResumeMarkdown) {
+      try {
+        let formatted = '';
+        for await (const event of sendMessage({
+          provider: state.provider,
+          apiKey: state.apiKey,
+          systemPrompt: RESUME_FORMATTING_SYSTEM_PROMPT,
+          messages: [{ role: 'user' as const, content: state.resumeText }],
+          maxTokens: 4096,
+        })) {
+          if (event.type === 'text') {
+            formatted += event.text;
+          }
+        }
+        if (formatted.trim()) {
+          dispatch({ type: 'SET_UPDATED_RESUME_MARKDOWN', updatedResumeMarkdown: formatted });
+        }
+      } catch (error) {
+        console.warn('Resume formatting failed:', error);
+      }
+    }
+    runChatTurn([]);
+  }
+
   useEffect(() => {
     if (!areAllStepsComplete(state) || !state.apiKey) {
       router.replace(state.wizardStep === 'setup' ? '/' : '/next-steps');
@@ -116,7 +154,7 @@ export default function ChatPage() {
 
     if (!initializedRef.current && state.chatMessages.length === 0) {
       initializedRef.current = true;
-      runChatTurn([]);
+      initializeChat();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -124,6 +162,13 @@ export default function ChatPage() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [state.chatMessages, streamingContent]);
+
+  useEffect(() => {
+    if (resumeJustUpdated) {
+      const timer = setTimeout(() => setResumeJustUpdated(false), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [resumeJustUpdated]);
 
   async function handleSend(text: string) {
     const userMessage: ChatMessageType = { role: 'user', content: text };
@@ -136,6 +181,7 @@ export default function ChatPage() {
       state.questionResponses,
       state.rankingState.sortedResult,
       state.resumeText,
+      state.updatedResumeMarkdown,
     );
     if (md) downloadTextFile(md, 'career-genie-results.md');
   }
@@ -167,6 +213,17 @@ export default function ChatPage() {
         </div>
 
         <div className="sticky bottom-0 bg-stone-50 pt-2 pb-4">
+          {resumeJustUpdated && (
+            <div className="flex items-center justify-center gap-2 py-1.5 text-xs text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg mb-2">
+              <span>Resume updated</span>
+              <button
+                onClick={() => setActivePanel('resume')}
+                className="underline font-medium hover:text-emerald-900"
+              >
+                View
+              </button>
+            </div>
+          )}
           <ChatInput
             onSend={handleSend}
             disabled={streaming}
@@ -199,7 +256,7 @@ export default function ChatPage() {
         open={activePanel === 'resume'}
         onClose={() => setActivePanel(null)}
       >
-        <ResumePanel resumeText={state.resumeText} />
+        <ResumePanel resumeText={state.resumeText} updatedResumeMarkdown={state.updatedResumeMarkdown} />
       </ChatPanel>
     </main>
   );

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -23,6 +23,7 @@ export default function ChatPage() {
   const [streamingContent, setStreamingContent] = useState('');
   const [activePanel, setActivePanel] = useState<'answers' | 'rankings' | 'resume' | null>(null);
   const [resumeJustUpdated, setResumeJustUpdated] = useState(false);
+  const [formattingResume, setFormattingResume] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const initializedRef = useRef(false);
 
@@ -122,6 +123,7 @@ export default function ChatPage() {
   }
 
   async function initializeChat() {
+    setFormattingResume(true);
     if (state.resumeText.trim() && !state.updatedResumeMarkdown) {
       try {
         let formatted = '';
@@ -143,6 +145,7 @@ export default function ChatPage() {
         console.warn('Resume formatting failed:', error);
       }
     }
+    setFormattingResume(false);
     runChatTurn([]);
   }
 
@@ -206,6 +209,9 @@ export default function ChatPage() {
             .map((msg, i) => (
               <ChatMessage key={i} message={msg} />
             ))}
+          {formattingResume && (
+            <p className="text-center text-sm text-stone-400 py-8">Preparing your resume...</p>
+          )}
           {streaming && streamingContent && (
             <ChatMessage message={{ role: 'assistant', content: streamingContent }} />
           )}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -265,6 +265,7 @@ export default function ChatPage() {
         title="Resume"
         open={activePanel === 'resume'}
         onClose={() => setActivePanel(null)}
+        wide
       >
         <ResumePanel resumeText={state.resumeText} updatedResumeMarkdown={state.updatedResumeMarkdown} />
       </ChatPanel>

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -14,6 +14,7 @@ import { RankingsPanel } from '@/components/RankingsPanel';
 import { ResumePanel } from '@/components/ResumePanel';
 import { CHAT_TOOLS, executeToolCall } from '@/lib/chat-tools';
 import { buildExportMarkdown, downloadTextFile } from '@/lib/export';
+import { ANTHROPIC_FAST_MODEL, OPENAI_FAST_MODEL } from '@/lib/models';
 import type { ChatMessage as ChatMessageType, ToolCall } from '@/types';
 
 export default function ChatPage() {
@@ -128,8 +129,8 @@ export default function ChatPage() {
       try {
         let formatted = '';
         const fastModel = state.provider === 'anthropic'
-          ? 'claude-haiku-4-5-20251001'
-          : 'gpt-5-mini-2025-08-07';
+          ? ANTHROPIC_FAST_MODEL
+          : OPENAI_FAST_MODEL;
         for await (const event of sendMessage({
           provider: state.provider,
           apiKey: state.apiKey,

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -129,7 +129,7 @@ export default function ChatPage() {
         let formatted = '';
         const fastModel = state.provider === 'anthropic'
           ? 'claude-haiku-4-5-20251001'
-          : 'gpt-5.4-mini';
+          : 'gpt-5-mini-2025-08-07';
         for await (const event of sendMessage({
           provider: state.provider,
           apiKey: state.apiKey,

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -7,15 +7,18 @@ interface ChatPanelProps {
   open: boolean;
   onClose: () => void;
   children: ReactNode;
+  wide?: boolean;
 }
 
-export function ChatPanel({ title, open, onClose, children }: ChatPanelProps) {
+export function ChatPanel({ title, open, onClose, children, wide }: ChatPanelProps) {
   if (!open) return null;
+
+  const widthClass = wide ? 'w-[48rem] max-w-[90vw]' : 'w-96 max-w-[90vw]';
 
   return (
     <>
       <div className="fixed inset-0 bg-black/20 z-40" onClick={onClose} />
-      <div className="fixed top-0 right-0 h-full w-96 max-w-[90vw] bg-stone-50 shadow-xl z-50 flex flex-col">
+      <div className={`fixed top-0 right-0 h-full ${widthClass} bg-stone-50 shadow-xl z-50 flex flex-col`}>
         <div className="flex items-center justify-between p-4 border-b border-stone-200">
           <h2 className="font-semibold text-stone-900">{title}</h2>
           <button

--- a/src/components/ResumePanel.tsx
+++ b/src/components/ResumePanel.tsx
@@ -48,8 +48,19 @@ export function ResumePanel({ resumeText, updatedResumeMarkdown }: ResumePanelPr
       {showOriginal ? (
         <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans leading-relaxed">{resumeText}</pre>
       ) : (
-        <div className="prose prose-sm prose-stone max-w-none">
-          <ReactMarkdown>{updatedResumeMarkdown}</ReactMarkdown>
+        <div className="prose prose-sm prose-stone max-w-none text-sm text-stone-800 leading-relaxed">
+          <ReactMarkdown components={{
+            h1: ({ children }) => <h1 className="text-xl font-bold text-stone-900 mt-4 mb-2">{children}</h1>,
+            h2: ({ children }) => <h2 className="text-lg font-semibold text-stone-900 mt-4 mb-1.5 border-b border-stone-200 pb-1">{children}</h2>,
+            h3: ({ children }) => <h3 className="text-base font-semibold text-stone-900 mt-3 mb-1">{children}</h3>,
+            p: ({ children }) => <p className="my-1.5 leading-relaxed">{children}</p>,
+            ul: ({ children }) => <ul className="my-1.5 pl-5 list-disc">{children}</ul>,
+            ol: ({ children }) => <ol className="my-1.5 pl-5 list-decimal">{children}</ol>,
+            li: ({ children }) => <li className="my-0.5">{children}</li>,
+            strong: ({ children }) => <strong className="font-semibold text-stone-900">{children}</strong>,
+            em: ({ children }) => <em className="text-stone-500 not-italic text-sm">{children}</em>,
+            hr: () => <hr className="my-3 border-stone-200" />,
+          }}>{updatedResumeMarkdown}</ReactMarkdown>
         </div>
       )}
     </div>

--- a/src/components/ResumePanel.tsx
+++ b/src/components/ResumePanel.tsx
@@ -1,13 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { downloadTextFile } from '@/lib/export';
+
 interface ResumePanelProps {
   resumeText: string;
+  updatedResumeMarkdown: string;
 }
 
-export function ResumePanel({ resumeText }: ResumePanelProps) {
-  if (!resumeText.trim()) {
+export function ResumePanel({ resumeText, updatedResumeMarkdown }: ResumePanelProps) {
+  const [showOriginal, setShowOriginal] = useState(false);
+  const hasUpdated = updatedResumeMarkdown.trim().length > 0;
+
+  if (!resumeText.trim() && !hasUpdated) {
     return <p className="text-sm text-stone-500">No resume uploaded.</p>;
   }
 
+  function handleDownloadResume() {
+    const content = updatedResumeMarkdown || resumeText;
+    downloadTextFile(content, 'resume.md');
+  }
+
+  if (!hasUpdated) {
+    return (
+      <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans leading-relaxed">{resumeText}</pre>
+    );
+  }
+
   return (
-    <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans leading-relaxed">{resumeText}</pre>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <button
+          onClick={() => setShowOriginal(!showOriginal)}
+          className="text-xs text-indigo-600 hover:text-indigo-800 underline"
+        >
+          {showOriginal ? 'Show updated' : 'Show original'}
+        </button>
+        <button
+          onClick={handleDownloadResume}
+          className="text-xs px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+        >
+          Download Resume (.md)
+        </button>
+      </div>
+
+      {showOriginal ? (
+        <pre className="whitespace-pre-wrap text-sm text-stone-800 font-sans leading-relaxed">{resumeText}</pre>
+      ) : (
+        <div className="prose prose-sm prose-stone max-w-none">
+          <ReactMarkdown>{updatedResumeMarkdown}</ReactMarkdown>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -46,6 +46,7 @@ export const initialState: SessionState = {
     isComplete: false,
   })),
   resumeText: '',
+  updatedResumeMarkdown: '',
   chatMessages: [],
   systemPrompt: '',
   rankingState: defaultRankingState,
@@ -68,6 +69,8 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
       return { ...state, questionResponses: state.questionResponses.map((qr) => qr.questionId === action.questionId ? { ...qr, whyAnswer: action.whyAnswer } : qr) };
     case 'SET_RESUME_TEXT':
       return { ...state, resumeText: action.resumeText };
+    case 'SET_UPDATED_RESUME_MARKDOWN':
+      return { ...state, updatedResumeMarkdown: action.updatedResumeMarkdown };
     case 'SET_QUESTION_COMPLETE':
       return {
         ...state,
@@ -100,6 +103,7 @@ export function sessionReducer(state: SessionState, action: SessionAction): Sess
         questionResponses: action.questionResponses,
         rankingState,
         resumeText: action.resumeText || '',
+        updatedResumeMarkdown: action.updatedResumeMarkdown || '',
         wizardStep: 'hub',
       };
     }

--- a/src/context/__tests__/SessionContext.test.tsx
+++ b/src/context/__tests__/SessionContext.test.tsx
@@ -47,6 +47,11 @@ describe('sessionReducer', () => {
     expect(state.resumeText).toBe('My resume content...');
   });
 
+  it('sets updated resume markdown', () => {
+    const state = sessionReducer(initialState, { type: 'SET_UPDATED_RESUME_MARKDOWN', updatedResumeMarkdown: '# Resume\n\n## Experience' });
+    expect(state.updatedResumeMarkdown).toBe('# Resume\n\n## Experience');
+  });
+
   it('merges partial ranking state', () => {
     const state = sessionReducer(initialState, { type: 'SET_RANKING_STATE', rankingState: { completedComparisons: 5 } });
     expect(state.rankingState.completedComparisons).toBe(5);
@@ -116,6 +121,32 @@ describe('sessionReducer', () => {
       sortedResult: null,
     });
     expect(state.resumeText).toBe('');
+  });
+
+  it('restores session with updatedResumeMarkdown', () => {
+    const state = sessionReducer(initialState, {
+      type: 'RESTORE_SESSION',
+      questionResponses: initialState.questionResponses,
+      sortedResult: null,
+      resumeText: 'raw',
+      updatedResumeMarkdown: '# Formatted',
+    });
+    expect(state.updatedResumeMarkdown).toBe('# Formatted');
+  });
+
+  it('restores session without updatedResumeMarkdown (backward compat)', () => {
+    const state = sessionReducer(initialState, {
+      type: 'RESTORE_SESSION',
+      questionResponses: initialState.questionResponses,
+      sortedResult: null,
+    });
+    expect(state.updatedResumeMarkdown).toBe('');
+  });
+
+  it('resets updatedResumeMarkdown', () => {
+    let state = sessionReducer(initialState, { type: 'SET_UPDATED_RESUME_MARKDOWN', updatedResumeMarkdown: '# Resume' });
+    state = sessionReducer(state, { type: 'RESET' });
+    expect(state.updatedResumeMarkdown).toBe('');
   });
 });
 

--- a/src/lib/__tests__/chat-tools.test.ts
+++ b/src/lib/__tests__/chat-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { executeUpdateRankings, CHAT_TOOLS } from '../chat-tools';
+import { executeUpdateRankings, executeUpdateResume, executeToolCall, CHAT_TOOLS } from '../chat-tools';
 
 const SAMPLE_ITEMS = [
   'High base compensation',
@@ -8,10 +8,10 @@ const SAMPLE_ITEMS = [
 ];
 
 describe('CHAT_TOOLS', () => {
-  it('exports update_rankings tool definition', () => {
-    expect(CHAT_TOOLS).toHaveLength(1);
-    expect(CHAT_TOOLS[0].name).toBe('update_rankings');
-    expect(CHAT_TOOLS[0].inputSchema).toBeDefined();
+  it('exports both tool definitions', () => {
+    expect(CHAT_TOOLS).toHaveLength(2);
+    expect(CHAT_TOOLS.map((t) => t.name)).toContain('update_rankings');
+    expect(CHAT_TOOLS.map((t) => t.name)).toContain('update_resume');
   });
 });
 
@@ -71,5 +71,63 @@ describe('executeUpdateRankings', () => {
       'High base compensation',
       'Work-life balance / flexible hours',
     ]);
+  });
+});
+
+describe('executeUpdateResume', () => {
+  it('accepts a valid resume string', () => {
+    const result = executeUpdateResume({ resume: '# John Doe\n\n## Experience\n...' });
+    expect(result.success).toBe(true);
+    expect(result.newResume).toBe('# John Doe\n\n## Experience\n...');
+    expect(result.resultText).toContain('updated successfully');
+  });
+
+  it('rejects non-string input', () => {
+    const result = executeUpdateResume({ resume: 123 });
+    expect(result.success).toBe(false);
+    expect(result.resultText).toContain('must be a string');
+  });
+
+  it('rejects empty string', () => {
+    const result = executeUpdateResume({ resume: '   ' });
+    expect(result.success).toBe(false);
+    expect(result.resultText).toContain('must not be empty');
+  });
+});
+
+describe('executeToolCall', () => {
+  it('routes update_rankings calls', () => {
+    const result = executeToolCall(
+      { id: 'tc_1', name: 'update_rankings', input: { rankings: ['Remote work options', 'High base compensation', 'Work-life balance / flexible hours'] } },
+      SAMPLE_ITEMS,
+    );
+    expect(result.newRankings).toBeDefined();
+    expect(result.resultText).toContain('Rankings updated');
+  });
+
+  it('routes update_resume calls', () => {
+    const result = executeToolCall(
+      { id: 'tc_2', name: 'update_resume', input: { resume: '# Resume' } },
+      [],
+    );
+    expect(result.newResume).toBe('# Resume');
+    expect(result.resultText).toContain('updated successfully');
+  });
+
+  it('returns no newResume on validation failure', () => {
+    const result = executeToolCall(
+      { id: 'tc_3', name: 'update_resume', input: { resume: '' } },
+      [],
+    );
+    expect(result.newResume).toBeUndefined();
+    expect(result.resultText).toContain('Error');
+  });
+
+  it('returns error for unknown tool', () => {
+    const result = executeToolCall(
+      { id: 'tc_4', name: 'unknown_tool', input: {} },
+      [],
+    );
+    expect(result.resultText).toContain('unknown tool');
   });
 });

--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -53,6 +53,25 @@ describe('buildExportMarkdown', () => {
     const md = buildExportMarkdown(questionResponses, ['Salary'], '');
     expect(md).not.toContain('## Resume');
   });
+
+  it('includes Updated Resume section when updatedResumeMarkdown provided', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'A1', whyAnswer: '', isComplete: true },
+    ];
+    const md = buildExportMarkdown(questionResponses, ['Salary'], 'raw', '# Formatted Resume');
+    expect(md).toContain('## Resume');
+    expect(md).toContain('## Updated Resume');
+    expect(md).toContain('# Formatted Resume');
+  });
+
+  it('omits Updated Resume section when updatedResumeMarkdown is empty', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'A1', whyAnswer: '', isComplete: true },
+    ];
+    const md = buildExportMarkdown(questionResponses, ['Salary'], 'raw', '');
+    expect(md).toContain('## Resume');
+    expect(md).not.toContain('## Updated Resume');
+  });
 });
 
 describe('buildExportText', () => {

--- a/src/lib/__tests__/llm-client.test.ts
+++ b/src/lib/__tests__/llm-client.test.ts
@@ -174,6 +174,44 @@ describe('sendMessage', () => {
     expect(body.stream).toBe(true);
   });
 
+  it('uses custom maxTokens for Anthropic when provided', async () => {
+    const stream = makeStream([
+      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}\n\n',
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]);
+    fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
+
+    for await (const _ of sendMessage({
+      provider: 'anthropic',
+      apiKey: 'sk-ant-test',
+      systemPrompt: 'test',
+      messages: [{ role: 'user', content: 'Hello' }],
+      maxTokens: 4096,
+    })) { /* consume */ }
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  it('uses custom maxTokens for OpenAI when provided', async () => {
+    const stream = makeStream([
+      'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    fetchSpy.mockResolvedValue(new Response(stream, { status: 200 }));
+
+    for await (const _ of sendMessage({
+      provider: 'openai',
+      apiKey: 'sk-test',
+      systemPrompt: 'test',
+      messages: [{ role: 'user', content: 'Hello' }],
+      maxTokens: 2048,
+    })) { /* consume */ }
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.max_tokens).toBe(2048);
+  });
+
   it('throws generic error on failure without leaking upstream body', async () => {
     fetchSpy.mockResolvedValue(new Response('{"error":"secret details"}', { status: 401 }));
 

--- a/src/lib/__tests__/llm-client.test.ts
+++ b/src/lib/__tests__/llm-client.test.ts
@@ -147,7 +147,7 @@ describe('sendMessage', () => {
     expect(body.stream).toBe(true);
   });
 
-  it('calls OpenAI directly with correct URL and max_tokens', async () => {
+  it('calls OpenAI directly with correct URL and max_completion_tokens', async () => {
     const stream = makeStream([
       'data: {"choices":[{"delta":{"content":"Hi"}}]}\n\n',
       'data: [DONE]\n\n',
@@ -170,7 +170,7 @@ describe('sendMessage', () => {
       expect.objectContaining({ method: 'POST' }),
     );
     const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
-    expect(body.max_tokens).toBe(1024);
+    expect(body.max_completion_tokens).toBe(1024);
     expect(body.stream).toBe(true);
   });
 
@@ -209,7 +209,7 @@ describe('sendMessage', () => {
     })) { /* consume */ }
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
-    expect(body.max_tokens).toBe(2048);
+    expect(body.max_completion_tokens).toBe(2048);
   });
 
   it('throws generic error on failure without leaking upstream body', async () => {

--- a/src/lib/__tests__/prompts.test.ts
+++ b/src/lib/__tests__/prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildChatSystemPrompt } from '../prompts';
+import { buildChatSystemPrompt, RESUME_FORMATTING_SYSTEM_PROMPT } from '../prompts';
 
 describe('buildChatSystemPrompt', () => {
   it('injects question responses and rankings into system prompt', () => {
@@ -72,5 +72,39 @@ describe('buildChatSystemPrompt', () => {
     ];
     const result = buildChatSystemPrompt(questionResponses, ['A'], 'My resume');
     expect(result).not.toContain('Obtain Resume');
+  });
+
+  it('prefers updatedResumeMarkdown over resumeText in resume block', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'A1', whyAnswer: '', isComplete: true },
+    ];
+    const result = buildChatSystemPrompt(questionResponses, ['A'], 'raw resume', '# Formatted Resume');
+    expect(result).toContain('# Formatted Resume');
+    expect(result).not.toContain('raw resume');
+  });
+
+  it('falls back to resumeText when updatedResumeMarkdown is empty', () => {
+    const questionResponses = [
+      { questionId: 0, question: 'Q1', answer: 'A1', whyAnswer: '', isComplete: true },
+    ];
+    const result = buildChatSystemPrompt(questionResponses, ['A'], 'raw resume', '');
+    expect(result).toContain('raw resume');
+  });
+
+  it('omits resume block when both resumeText and updatedResumeMarkdown are empty', () => {
+    const result = buildChatSystemPrompt([], [], '', '');
+    expect(result).not.toContain('<resume>');
+  });
+
+  it('includes update_resume in tools guidance', () => {
+    const result = buildChatSystemPrompt([], []);
+    expect(result).toContain('update_resume');
+  });
+});
+
+describe('RESUME_FORMATTING_SYSTEM_PROMPT', () => {
+  it('mentions markdown and preservation of original wording', () => {
+    expect(RESUME_FORMATTING_SYSTEM_PROMPT).toContain('markdown');
+    expect(RESUME_FORMATTING_SYSTEM_PROMPT).toContain('Preserve ALL');
   });
 });

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -20,7 +20,24 @@ export const UPDATE_RANKINGS_TOOL: ToolDefinition = {
   },
 };
 
-export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL];
+export const UPDATE_RESUME_TOOL: ToolDefinition = {
+  name: 'update_resume',
+  description:
+    'Update the user\'s resume. Provide the complete updated resume as a single markdown string. This performs a full replacement of the resume each time.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      resume: {
+        type: 'string',
+        description:
+          'The complete updated resume in markdown format. Must be the full resume, not a partial update.',
+      },
+    },
+    required: ['resume'],
+  },
+};
+
+export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL, UPDATE_RESUME_TOOL];
 
 export function executeUpdateRankings(
   input: Record<string, unknown>,
@@ -60,15 +77,42 @@ export function executeUpdateRankings(
   return { success: true, resultText, newRankings };
 }
 
+export function executeUpdateResume(
+  input: Record<string, unknown>,
+): { success: boolean; resultText: string; newResume?: string } {
+  const resume = input.resume;
+
+  if (typeof resume !== 'string') {
+    return { success: false, resultText: 'Error: resume must be a string.' };
+  }
+
+  if (!resume.trim()) {
+    return { success: false, resultText: 'Error: resume must not be empty.' };
+  }
+
+  return {
+    success: true,
+    resultText: 'Resume updated successfully.',
+    newResume: resume,
+  };
+}
+
 export function executeToolCall(
   toolCall: ToolCall,
   currentRankings: string[],
-): { resultText: string; newRankings?: string[] } {
+): { resultText: string; newRankings?: string[]; newResume?: string } {
   if (toolCall.name === 'update_rankings') {
     const result = executeUpdateRankings(toolCall.input, currentRankings);
     return {
       resultText: result.resultText,
       newRankings: result.success ? result.newRankings : undefined,
+    };
+  }
+  if (toolCall.name === 'update_resume') {
+    const result = executeUpdateResume(toolCall.input);
+    return {
+      resultText: result.resultText,
+      newResume: result.success ? result.newResume : undefined,
     };
   }
   return { resultText: `Error: unknown tool "${toolCall.name}".` };

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -5,6 +5,7 @@ export function buildExportMarkdown(
   questionResponses: QuestionResponse[],
   rankedQualities: string[] | null,
   resumeText?: string,
+  updatedResumeMarkdown?: string,
 ): string {
   const sections: string[] = [];
 
@@ -34,6 +35,10 @@ export function buildExportMarkdown(
     sections.push('## Resume\n\n' + resumeText.trim());
   }
 
+  if (updatedResumeMarkdown && updatedResumeMarkdown.trim()) {
+    sections.push('## Updated Resume\n\n' + updatedResumeMarkdown.trim());
+  }
+
   if (sections.length <= 2) return '';
 
   return sections.join('\n\n') + '\n';
@@ -43,8 +48,9 @@ export function buildCopyablePrompt(
   questionResponses: QuestionResponse[],
   rankedQualities: string[] | null,
   resumeText?: string,
+  updatedResumeMarkdown?: string,
 ): string {
-  return buildChatSystemPrompt(questionResponses, rankedQualities || [], resumeText)
+  return buildChatSystemPrompt(questionResponses, rankedQualities || [], resumeText, updatedResumeMarkdown)
     + '\n\nBegin the coaching session.';
 }
 

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -1,4 +1,5 @@
 import type { Provider, ChatMessage, ToolDefinition, StreamEvent } from '@/types';
+import { ANTHROPIC_CHAT_MODEL, OPENAI_CHAT_MODEL } from './models';
 
 interface SendMessageParams {
   provider: Provider;
@@ -111,7 +112,7 @@ export async function* sendMessage(
   const body =
     provider === 'anthropic'
       ? {
-          model: model || 'claude-sonnet-4-6',
+          model: model || ANTHROPIC_CHAT_MODEL,
           max_tokens: maxTokens,
           system: systemPrompt,
           messages: toAnthropicMessages(effectiveMessages),
@@ -119,7 +120,7 @@ export async function* sendMessage(
           ...(anthropicTools ? { tools: anthropicTools } : {}),
         }
       : {
-          model: model || 'gpt-4o',
+          model: model || OPENAI_CHAT_MODEL,
           messages: toOpenAIMessages(effectiveMessages, systemPrompt),
           max_completion_tokens: maxTokens,
           stream: true,
@@ -151,8 +152,8 @@ export async function* sendMessage(
 export async function validateApiKey(provider: Provider, apiKey: string): Promise<void> {
   const body =
     provider === 'anthropic'
-      ? { model: 'claude-sonnet-4-6', max_tokens: 16, system: 'Reply with exactly: ok', messages: [{ role: 'user', content: 'Hello' }] }
-      : { model: 'gpt-4o', messages: [{ role: 'system', content: 'Reply with exactly: ok' }, { role: 'user', content: 'Hello' }], max_completion_tokens: 16 };
+      ? { model: ANTHROPIC_CHAT_MODEL, max_tokens: 16, system: 'Reply with exactly: ok', messages: [{ role: 'user', content: 'Hello' }] }
+      : { model: OPENAI_CHAT_MODEL, messages: [{ role: 'system', content: 'Reply with exactly: ok' }, { role: 'user', content: 'Hello' }], max_completion_tokens: 16 };
 
   const { url, init } = buildProviderRequest(provider, apiKey, body);
   const response = await fetch(url, init);

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -121,7 +121,7 @@ export async function* sendMessage(
       : {
           model: model || 'gpt-4o',
           messages: toOpenAIMessages(effectiveMessages, systemPrompt),
-          max_tokens: maxTokens,
+          max_completion_tokens: maxTokens,
           stream: true,
           ...(openaiTools ? { tools: openaiTools } : {}),
         };
@@ -146,7 +146,7 @@ export async function validateApiKey(provider: Provider, apiKey: string): Promis
   const body =
     provider === 'anthropic'
       ? { model: 'claude-sonnet-4-6', max_tokens: 16, system: 'Reply with exactly: ok', messages: [{ role: 'user', content: 'Hello' }] }
-      : { model: 'gpt-4o', messages: [{ role: 'system', content: 'Reply with exactly: ok' }, { role: 'user', content: 'Hello' }], max_tokens: 16 };
+      : { model: 'gpt-4o', messages: [{ role: 'system', content: 'Reply with exactly: ok' }, { role: 'user', content: 'Hello' }], max_completion_tokens: 16 };
 
   const { url, init } = buildProviderRequest(provider, apiKey, body);
   const response = await fetch(url, init);

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -6,6 +6,7 @@ interface SendMessageParams {
   systemPrompt: string;
   messages: ChatMessage[];
   tools?: ToolDefinition[];
+  maxTokens?: number;
 }
 
 function buildProviderRequest(
@@ -90,7 +91,7 @@ export function toOpenAIMessages(messages: ChatMessage[], systemPrompt: string):
 export async function* sendMessage(
   params: SendMessageParams,
 ): AsyncGenerator<StreamEvent> {
-  const { provider, apiKey, systemPrompt, messages, tools } = params;
+  const { provider, apiKey, systemPrompt, messages, tools, maxTokens = 1024 } = params;
 
   const effectiveMessages: ChatMessage[] = messages.length === 0
     ? [{ role: 'user' as const, content: 'Begin the coaching session' }]
@@ -110,7 +111,7 @@ export async function* sendMessage(
     provider === 'anthropic'
       ? {
           model: 'claude-sonnet-4-6',
-          max_tokens: 1024,
+          max_tokens: maxTokens,
           system: systemPrompt,
           messages: toAnthropicMessages(effectiveMessages),
           stream: true,
@@ -119,7 +120,7 @@ export async function* sendMessage(
       : {
           model: 'gpt-4o',
           messages: toOpenAIMessages(effectiveMessages, systemPrompt),
-          max_tokens: 1024,
+          max_tokens: maxTokens,
           stream: true,
           ...(openaiTools ? { tools: openaiTools } : {}),
         };

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -7,6 +7,7 @@ interface SendMessageParams {
   messages: ChatMessage[];
   tools?: ToolDefinition[];
   maxTokens?: number;
+  model?: string;
 }
 
 function buildProviderRequest(
@@ -91,7 +92,7 @@ export function toOpenAIMessages(messages: ChatMessage[], systemPrompt: string):
 export async function* sendMessage(
   params: SendMessageParams,
 ): AsyncGenerator<StreamEvent> {
-  const { provider, apiKey, systemPrompt, messages, tools, maxTokens = 1024 } = params;
+  const { provider, apiKey, systemPrompt, messages, tools, maxTokens = 1024, model } = params;
 
   const effectiveMessages: ChatMessage[] = messages.length === 0
     ? [{ role: 'user' as const, content: 'Begin the coaching session' }]
@@ -110,7 +111,7 @@ export async function* sendMessage(
   const body =
     provider === 'anthropic'
       ? {
-          model: 'claude-sonnet-4-6',
+          model: model || 'claude-sonnet-4-6',
           max_tokens: maxTokens,
           system: systemPrompt,
           messages: toAnthropicMessages(effectiveMessages),
@@ -118,7 +119,7 @@ export async function* sendMessage(
           ...(anthropicTools ? { tools: anthropicTools } : {}),
         }
       : {
-          model: 'gpt-4o',
+          model: model || 'gpt-4o',
           messages: toOpenAIMessages(effectiveMessages, systemPrompt),
           max_tokens: maxTokens,
           stream: true,

--- a/src/lib/llm-client.ts
+++ b/src/lib/llm-client.ts
@@ -130,7 +130,13 @@ export async function* sendMessage(
   const response = await fetch(url, init);
 
   if (!response.ok) {
-    throw new Error('Chat request failed. Please check your API key and try again.');
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Chat request failed. Please check your API key and try again.');
+    }
+    if (response.status === 529) {
+      throw new Error('The AI provider is currently overloaded. Please try again in a moment.');
+    }
+    throw new Error(`Chat request failed (status ${response.status}). Please try again.`);
   }
 
   if (!response.body) throw new Error('No response body');
@@ -152,7 +158,13 @@ export async function validateApiKey(provider: Provider, apiKey: string): Promis
   const response = await fetch(url, init);
 
   if (!response.ok) {
-    throw new Error('Invalid API key. Please check your key and try again.');
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Invalid API key. Please check your key and try again.');
+    }
+    if (response.status === 529) {
+      throw new Error('The AI provider is currently overloaded. Please try again in a moment.');
+    }
+    throw new Error(`API key validation failed (status ${response.status}). Please try again.`);
   }
 }
 
@@ -179,7 +191,12 @@ export async function* parseAnthropicStream(
         try {
           const parsed = JSON.parse(data);
 
-          if (parsed.type === 'content_block_start' && parsed.content_block?.type === 'tool_use') {
+          if (parsed.type === 'error') {
+            const msg = parsed.error?.type === 'overloaded_error'
+              ? 'The AI provider is currently overloaded. Please try again in a moment.'
+              : parsed.error?.message || 'An unexpected error occurred.';
+            throw new Error(msg);
+          } else if (parsed.type === 'content_block_start' && parsed.content_block?.type === 'tool_use') {
             pendingToolCall = {
               id: parsed.content_block.id,
               name: parsed.content_block.name,
@@ -201,8 +218,9 @@ export async function* parseAnthropicStream(
             };
             pendingToolCall = null;
           }
-        } catch {
-          // skip non-JSON lines
+        } catch (e) {
+          if (e instanceof SyntaxError) continue;
+          throw e;
         }
       }
     }
@@ -259,8 +277,9 @@ export async function* parseOpenAIStream(
             }
             pendingToolCalls.clear();
           }
-        } catch {
-          // skip non-JSON lines
+        } catch (e) {
+          if (e instanceof SyntaxError) continue;
+          throw e;
         }
       }
     }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,0 +1,11 @@
+export const ANTHROPIC_CHAT_MODEL =
+  process.env.NEXT_PUBLIC_ANTHROPIC_CHAT_MODEL || 'claude-sonnet-4-6';
+
+export const OPENAI_CHAT_MODEL =
+  process.env.NEXT_PUBLIC_OPENAI_CHAT_MODEL || 'gpt-4o';
+
+export const ANTHROPIC_FAST_MODEL =
+  process.env.NEXT_PUBLIC_ANTHROPIC_FAST_MODEL || 'claude-haiku-4-5-20251001';
+
+export const OPENAI_FAST_MODEL =
+  process.env.NEXT_PUBLIC_OPENAI_FAST_MODEL || 'gpt-5-mini-2025-08-07';

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -4,10 +4,18 @@ export const RESUME_FORMATTING_SYSTEM_PROMPT = `You are a resume formatting assi
 
 Rules:
 - Preserve ALL of the user's original wording exactly. Do not add, remove, or rephrase any content.
-- Add markdown structure: use ## for section headers (e.g., Experience, Education, Skills), use bullet points for lists, use **bold** for job titles and company names.
 - Use consistent formatting throughout.
 - If the resume already has clear sections, preserve that structure.
-- Output ONLY the formatted resume markdown. No commentary, no preamble, no explanation.`;
+- Output ONLY the formatted resume markdown. No commentary, no preamble, no explanation.
+
+Markdown structure to use:
+- # for the person's full name (h1)
+- *italics* for contact details on the line immediately after the name (e.g., *City, ST | 555-123-4567 | email@example.com*)
+- ## for major section headers (e.g., Profile, Experience, Education, Skills)
+- **bold** for job titles and company names within list items
+- Bullet points (-) for job responsibilities and list items
+- Nested bullets for sub-details under a job entry
+- --- (horizontal rule) to separate the header from the body if it improves readability`;
 
 const CHAT_SYSTEM_PROMPT_TEMPLATE = `<instructions>
 You are a clever and wise genie, summoned to serve as a career coach for a person who wants guidance. Your goal is to help the user create a plan to achieve their "dream job" within 5 years (or as close to it as is realistic). Note: a dream job may not be a job at all but could be owning their own business, or multiple jobs, etc…
@@ -41,6 +49,8 @@ You also have access to an update_resume tool that can update the user's resume.
 - You've identified concrete changes based on the coaching discussion
 
 When updating the resume, provide the COMPLETE updated resume as markdown. Always confirm planned changes with the user before calling the tool. After using the tool, briefly describe what was changed.
+
+Resume markdown format: use # for the person's name, *italics* for contact info, ## for section headers, **bold** for job titles/companies, bullet points for responsibilities, and nested bullets for sub-details.
 </tools_guidance>
 
 {{REFLECTION_ANSWERS}}

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,5 +1,14 @@
 import type { QuestionResponse } from '@/types';
 
+export const RESUME_FORMATTING_SYSTEM_PROMPT = `You are a resume formatting assistant. Your task is to convert raw resume text into clean, well-structured markdown.
+
+Rules:
+- Preserve ALL of the user's original wording exactly. Do not add, remove, or rephrase any content.
+- Add markdown structure: use ## for section headers (e.g., Experience, Education, Skills), use bullet points for lists, use **bold** for job titles and company names.
+- Use consistent formatting throughout.
+- If the resume already has clear sections, preserve that structure.
+- Output ONLY the formatted resume markdown. No commentary, no preamble, no explanation.`;
+
 const CHAT_SYSTEM_PROMPT_TEMPLATE = `<instructions>
 You are a clever and wise genie, summoned to serve as a career coach for a person who wants guidance. Your goal is to help the user create a plan to achieve their "dream job" within 5 years (or as close to it as is realistic). Note: a dream job may not be a job at all but could be owning their own business, or multiple jobs, etc…
 
@@ -26,7 +35,12 @@ You have access to an update_rankings tool that can reorder the user's career qu
 - The user explicitly asks to change their ranking order
 - The conversation reveals a clear shift in priorities that the user confirms
 
-Always confirm the intended change with the user before calling the tool. After using the tool, briefly acknowledge what changed.
+You also have access to an update_resume tool that can update the user's resume. Use it when:
+- You and the user have discussed specific improvements to their resume
+- The user asks you to update, revise, or rewrite parts of their resume
+- You've identified concrete changes based on the coaching discussion
+
+When updating the resume, provide the COMPLETE updated resume as markdown. Always confirm planned changes with the user before calling the tool. After using the tool, briefly describe what was changed.
 </tools_guidance>
 
 {{REFLECTION_ANSWERS}}
@@ -39,6 +53,7 @@ export function buildChatSystemPrompt(
   questionResponses: QuestionResponse[],
   rankedQualities: string[],
   resumeText?: string,
+  updatedResumeMarkdown?: string,
 ): string {
   const qaSummary = questionResponses
     .map((qr) => {
@@ -59,8 +74,9 @@ export function buildChatSystemPrompt(
   const rankingBlock = `<ranked_qualities>\n${rankingSummary}\n</ranked_qualities>`;
 
   let resumeBlock = '';
-  if (resumeText && resumeText.trim()) {
-    resumeBlock = `<resume>\n${resumeText.trim()}\n</resume>`;
+  const effectiveResume = updatedResumeMarkdown?.trim() || resumeText?.trim();
+  if (effectiveResume) {
+    resumeBlock = `<resume>\n${effectiveResume}\n</resume>`;
   }
 
   return CHAT_SYSTEM_PROMPT_TEMPLATE

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,7 @@ export interface SessionState {
   wizardStep: WizardStep;
   questionResponses: QuestionResponse[];
   resumeText: string;
+  updatedResumeMarkdown: string;
   chatMessages: ChatMessage[];
   systemPrompt: string;
   rankingState: RankingState;
@@ -63,6 +64,7 @@ export type SessionAction =
   | { type: 'SET_QUESTION_COMPLETE'; questionId: number }
   | { type: 'SET_RANKING_STATE'; rankingState: Partial<RankingState> }
   | { type: 'SET_RESUME_TEXT'; resumeText: string }
+  | { type: 'SET_UPDATED_RESUME_MARKDOWN'; updatedResumeMarkdown: string }
   | { type: 'SET_RESULTS'; results: string }
-  | { type: 'RESTORE_SESSION'; questionResponses: QuestionResponse[]; sortedResult: string[] | null; resumeText?: string }
+  | { type: 'RESTORE_SESSION'; questionResponses: QuestionResponse[]; sortedResult: string[] | null; resumeText?: string; updatedResumeMarkdown?: string }
   | { type: 'RESET' };


### PR DESCRIPTION
## Summary

Adds the interactive chat experience layer on top of the coaching session: a toolbar for reviewing session data, LLM tool calling for live updates, and a resume builder that formats and iterates on the user's resume.

### Chat toolbar & slide-out panels
- Sticky toolbar with buttons to open **Answers**, **Rankings**, and **Resume** panels, plus a download button
- Slide-out panels show session data alongside the chat without leaving the page
- Rankings panel supports drag-to-reorder with a **Save** button that batches edits into a single message to the LLM

### Tool call loop
- Full tool calling support for both Anthropic and OpenAI streaming APIs
- `update_rankings` tool lets the assistant reorder the user's priority rankings
- `update_resume` tool lets the assistant replace the resume with an improved version
- Multi-round tool execution (up to 3 rounds per turn) with proper message threading
- Provider-specific message converters handle tool_use/tool_result (Anthropic) and tool_calls/tool (OpenAI) wire formats

### Resume builder (#31)
- On entering chat, a fast LLM call (Haiku / GPT-5-mini) converts the raw uploaded resume to clean markdown
- "Preparing your resume..." loading indicator shown during formatting
- During chat, the assistant can update the resume via `update_resume` tool call (full replacement)
- Resume panel shows the formatted version by default with toggle to original and download (.md)
- Inline emerald notification bar when the resume is updated mid-conversation, auto-dismisses after 5s
- Updated resume included in session export

### Other improvements
- LLM model names configurable via `NEXT_PUBLIC_*` env vars for easy override
- Accurate error messages for API overload (529) and stream parsing errors
- `sendMessage` accepts optional `model` and `maxTokens` parameters

## Changed files

- `src/app/chat/page.tsx` — chat page with toolbar, tool loop, resume formatting, notifications
- `src/components/ChatToolbar.tsx` — sticky toolbar component
- `src/components/ChatPanel.tsx` — slide-out panel shell
- `src/components/AnswersPanel.tsx` — survey answers display
- `src/components/RankingsPanel.tsx` — drag-to-reorder rankings with Save
- `src/components/ResumePanel.tsx` — formatted resume with original toggle and download
- `src/lib/chat-tools.ts` — tool definitions and execution logic
- `src/lib/llm-client.ts` — streaming, tool call parsing, model/maxTokens params
- `src/lib/prompts.ts` — system prompt with resume and tool guidance
- `src/lib/export.ts` — updated resume section in export
- `src/lib/models.ts` — model name constants with env var overrides
- `src/types/index.ts` — tool call types, updated session state
- `src/context/SessionContext.tsx` — `updatedResumeMarkdown` state + reducer

## Test plan

- [ ] Enter chat with a resume uploaded — confirm "Preparing your resume..." appears and disappears
- [ ] Open Resume panel — formatted markdown version shown by default
- [ ] Toggle to original — raw text shown; toggle back — formatted version shown
- [ ] Download button produces valid `.md` file
- [ ] Ask the assistant to improve the resume — confirm `update_resume` tool fires, notification appears, panel updates
- [ ] Ask the assistant to reorder rankings — confirm `update_rankings` tool fires, panel updates
- [ ] Drag-reorder rankings in panel, click Save — message sent to chat
- [ ] Download export — includes both Resume and Updated Resume sections
- [ ] Test with both Anthropic and OpenAI providers
- [ ] Verify env var override works (`NEXT_PUBLIC_ANTHROPIC_CHAT_MODEL`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)