### PR TITLE
feat: add present_options tool for clickable choices in coaching chat

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -7,6 +7,7 @@ import { sendMessage } from '@/lib/llm-client';
 import { buildChatSystemPrompt, RESUME_FORMATTING_SYSTEM_PROMPT } from '@/lib/prompts';
 import { ChatMessage } from '@/components/ChatMessage';
 import { ChatInput } from '@/components/ChatInput';
+import { ChatOptions } from '@/components/ChatOptions';
 import { ChatToolbar } from '@/components/ChatToolbar';
 import { ChatPanel } from '@/components/ChatPanel';
 import { AnswersPanel } from '@/components/AnswersPanel';
@@ -15,7 +16,7 @@ import { ResumePanel } from '@/components/ResumePanel';
 import { CHAT_TOOLS, executeToolCall } from '@/lib/chat-tools';
 import { buildExportMarkdown, downloadTextFile } from '@/lib/export';
 import { ANTHROPIC_FAST_MODEL, OPENAI_FAST_MODEL } from '@/lib/models';
-import type { ChatMessage as ChatMessageType, ToolCall } from '@/types';
+import type { ChatMessage as ChatMessageType, PresentedOption, ToolCall } from '@/types';
 
 export default function ChatPage() {
   const { state, dispatch } = useSession();
@@ -67,6 +68,30 @@ export default function ChatPage() {
 
         if (toolCalls.length === 0) {
           dispatch({ type: 'ADD_CHAT_MESSAGE', message: { role: 'assistant', content } });
+          break;
+        }
+
+        const hasPresentOptions = toolCalls.some(tc => tc.name === 'present_options');
+        const hasOtherTools = toolCalls.some(tc => tc.name !== 'present_options');
+
+        if (hasPresentOptions && hasOtherTools) {
+          const assistantMsg: ChatMessageType = { role: 'assistant', content, toolCalls };
+          dispatch({ type: 'ADD_CHAT_MESSAGE', message: assistantMsg });
+          const errorResults: ChatMessageType[] = toolCalls.map(tc => ({
+            role: 'user' as const,
+            content: 'Error: present_options cannot be combined with other tool calls. Use present_options in a separate response.',
+            toolResult: { toolUseId: tc.id },
+          }));
+          for (const trm of errorResults) {
+            dispatch({ type: 'ADD_CHAT_MESSAGE', message: trm });
+          }
+          currentMessages = [...currentMessages, assistantMsg, ...errorResults];
+          setStreamingContent('');
+          continue;
+        }
+
+        if (hasPresentOptions) {
+          dispatch({ type: 'ADD_CHAT_MESSAGE', message: { role: 'assistant', content, toolCalls } });
           break;
         }
 
@@ -178,10 +203,37 @@ export default function ChatPage() {
     }
   }, [resumeJustUpdated]);
 
+  function getPendingOptionToolResults(messages: ChatMessageType[], userText: string): ChatMessageType[] {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.toolResult) continue;
+      if (msg.role === 'assistant' && msg.toolCalls) {
+        const presentOptions = msg.toolCalls.find(tc => tc.name === 'present_options');
+        if (presentOptions) {
+          const hasResult = messages.some(m => m.toolResult?.toolUseId === presentOptions.id);
+          if (!hasResult) {
+            return [{
+              role: 'user',
+              content: `User selected: ${userText}`,
+              toolResult: { toolUseId: presentOptions.id },
+            }];
+          }
+        }
+        break;
+      }
+      if (msg.role === 'user') break;
+    }
+    return [];
+  }
+
   async function handleSend(text: string) {
+    const pendingResults = getPendingOptionToolResults(state.chatMessages, text);
+    for (const result of pendingResults) {
+      dispatch({ type: 'ADD_CHAT_MESSAGE', message: result });
+    }
     const userMessage: ChatMessageType = { role: 'user', content: text };
     dispatch({ type: 'ADD_CHAT_MESSAGE', message: userMessage });
-    runChatTurn([...state.chatMessages, userMessage]);
+    runChatTurn([...state.chatMessages, ...pendingResults, userMessage]);
   }
 
   function handleDownload() {
@@ -210,10 +262,34 @@ export default function ChatPage() {
 
         <div className="flex-1 overflow-y-auto space-y-1">
           {state.chatMessages
-            .filter((msg) => !msg.toolResult)
-            .map((msg, i) => (
-              <ChatMessage key={i} message={msg} />
-            ))}
+            .map((msg, idx) => ({ msg, idx }))
+            .filter(({ msg }) => !msg.toolResult)
+            .map(({ msg, idx }, visibleIdx, visibleMessages) => {
+              const presentOptionsTc = msg.role === 'assistant' && msg.toolCalls?.find(tc => tc.name === 'present_options');
+              let optionState: { options: PresentedOption[]; disabled: boolean; selectedTitle: string | null } | null = null;
+              if (presentOptionsTc) {
+                const options = (presentOptionsTc.input as { options: PresentedOption[] }).options;
+                const nextUser = visibleMessages.slice(visibleIdx + 1).find(({ msg: m }) => m.role === 'user');
+                const disabled = !!nextUser || streaming;
+                const selectedTitle = nextUser && options.some(o => o.title === nextUser.msg.content)
+                  ? nextUser.msg.content
+                  : null;
+                optionState = { options, disabled, selectedTitle };
+              }
+              return (
+                <div key={idx}>
+                  <ChatMessage message={msg} />
+                  {optionState && (
+                    <ChatOptions
+                      options={optionState.options}
+                      onSelect={handleSend}
+                      disabled={optionState.disabled}
+                      selectedTitle={optionState.selectedTitle}
+                    />
+                  )}
+                </div>
+              );
+            })}
           {formattingResume && (
             <p className="text-center text-sm text-stone-400 py-8">Preparing your resume...</p>
           )}

--- a/src/components/ChatOptions.tsx
+++ b/src/components/ChatOptions.tsx
@@ -1,0 +1,37 @@
+import type { PresentedOption } from '@/types';
+
+interface ChatOptionsProps {
+  options: PresentedOption[];
+  onSelect: (title: string) => void;
+  disabled: boolean;
+  selectedTitle: string | null;
+}
+
+export function ChatOptions({ options, onSelect, disabled, selectedTitle }: ChatOptionsProps) {
+  return (
+    <div className="flex flex-col gap-2 my-3 ml-4">
+      {options.map((option) => {
+        const isSelected = selectedTitle === option.title;
+        const isDisabledUnselected = disabled && !isSelected;
+
+        return (
+          <button
+            key={option.title}
+            onClick={() => onSelect(option.title)}
+            disabled={disabled}
+            className={`text-left px-4 py-3 rounded-lg border transition-colors ${
+              isSelected
+                ? 'border-emerald-500 bg-emerald-50 text-emerald-900'
+                : isDisabledUnselected
+                  ? 'border-stone-200 bg-stone-50 opacity-50 cursor-default'
+                  : 'border-stone-300 bg-white hover:border-emerald-400 hover:bg-emerald-50 cursor-pointer'
+            }`}
+          >
+            <span className="font-medium">{option.title}</span>
+            <span className="block text-xs text-stone-500 mt-0.5">{option.description}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/__tests__/chat-tools.test.ts
+++ b/src/lib/__tests__/chat-tools.test.ts
@@ -8,10 +8,11 @@ const SAMPLE_ITEMS = [
 ];
 
 describe('CHAT_TOOLS', () => {
-  it('exports both tool definitions', () => {
-    expect(CHAT_TOOLS).toHaveLength(2);
+  it('exports all tool definitions', () => {
+    expect(CHAT_TOOLS).toHaveLength(3);
     expect(CHAT_TOOLS.map((t) => t.name)).toContain('update_rankings');
     expect(CHAT_TOOLS.map((t) => t.name)).toContain('update_resume');
+    expect(CHAT_TOOLS.map((t) => t.name)).toContain('present_options');
   });
 });
 

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -37,7 +37,33 @@ export const UPDATE_RESUME_TOOL: ToolDefinition = {
   },
 };
 
-export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL, UPDATE_RESUME_TOOL];
+export const PRESENT_OPTIONS_TOOL: ToolDefinition = {
+  name: 'present_options',
+  description:
+    'Present 2-4 clickable options to the user. Use this when asking the user to choose between distinct alternatives (e.g., dream job scenarios, plan directions). Do NOT also list the options as numbered items in the text.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      options: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', description: 'Short label for the option' },
+            description: { type: 'string', description: 'One-sentence description' },
+          },
+          required: ['title', 'description'],
+        },
+        minItems: 2,
+        maxItems: 4,
+        description: 'The options to present to the user.',
+      },
+    },
+    required: ['options'],
+  },
+};
+
+export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL, UPDATE_RESUME_TOOL, PRESENT_OPTIONS_TOOL];
 
 export function executeUpdateRankings(
   input: Record<string, unknown>,

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -51,6 +51,18 @@ You also have access to an update_resume tool that can update the user's resume.
 When updating the resume, provide the COMPLETE updated resume as markdown. Always confirm planned changes with the user before calling the tool. After using the tool, briefly describe what was changed.
 
 Resume markdown format: use # for the person's name, *italics* for contact info, ## for section headers, **bold** for job titles/companies, bullet points for responsibilities, and nested bullets for sub-details.
+
+You also have access to a present_options tool that displays clickable buttons to the user. Use it when:
+- You are presenting 2-4 distinct choices for the user to pick from (e.g., dream job scenarios, plan directions)
+- The choices are well-defined enough to have a short title and brief description
+
+Rules for present_options:
+- NEVER list the options as numbered items in your text message. The buttons ARE the options.
+- Your text message should provide context and ask the question, then let the buttons speak for themselves.
+- Always provide 2-4 options.
+- Each option needs a short title and a one-sentence description.
+- Do NOT combine present_options with other tool calls in the same response.
+- The user may click a button OR type a free-text response instead.
 </tools_guidance>
 
 {{REFLECTION_ANSWERS}}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,11 @@ export type StreamEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_call'; id: string; name: string; input: Record<string, unknown> };
 
+export interface PresentedOption {
+  title: string;
+  description: string;
+}
+
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;


### PR DESCRIPTION
## Summary
- Adds a `present_options` LLM tool that renders 2-4 clickable buttons in the coaching chat when the LLM presents multiple-choice questions (e.g., dream job scenarios, plan directions)
- The tool breaks the auto-execute tool loop and waits for user interaction — clicking a button sends the title as a user message, or the user can type free text instead
- Selected option highlights emerald, unselected ones dim, and the chat input remains active alongside the buttons

## Test plan
- [x] `npm test` — 103 tests pass (updated `CHAT_TOOLS` length assertion to 3)
- [x] `npm run build` — no type errors
- [x] Browser: LLM presents dream job scenarios as clickable buttons (not numbered text)
- [x] Browser: clicking an option sends title as user message, buttons disable, selected one highlights
- [x] Browser: LLM responds with follow-up text and new set of option buttons
- [ ] Browser: type free text instead of clicking — buttons disable with none highlighted
- [ ] Browser: `update_rankings` / `update_resume` tools still work normally

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)