### PR TITLE
feat: add selectable options UI for career chat (issue #34)

### DIFF
--- a/docs/design-selectable-options.md
+++ b/docs/design-selectable-options.md
@@ -1,0 +1,65 @@
+# Design Decisions: Selectable Options (Issue #34)
+
+GitHub issue: https://github.com/DerrickStuckey/career-genie/issues/34
+
+## Problem
+
+The career chat LLM frequently asks "which do you like of 1-4?" and similar multiple-choice questions. Users have to type or copy-paste their answer, which is clunky.
+
+## Decisions
+
+### How the LLM signals options: New tool call
+
+A dedicated `present_options` tool call, not markdown parsing. Parsing numbered lists from streamed text would be fragile — the LLM formats lists inconsistently. A tool call provides reliable, structured option data.
+
+### Option data model: Title + description
+
+Each option has a short `title` (sent as the user message when clicked) and a one-sentence `description`. This gives users enough context to decide without overwhelming the UI.
+
+### What gets sent on selection: Title only
+
+When the user clicks an option, only the `title` is sent as the user message. The LLM already has the full option context from its own tool call.
+
+### Free text always available
+
+The regular text input remains active when option buttons are shown. Users can type a custom response instead of clicking. This avoids boxing people into predefined choices.
+
+### Single-select only
+
+Always single-select — one click, one choice. If the LLM needs multiple inputs, it should ask follow-up questions. No `multiSelect` flag.
+
+### After selection: Disable all, highlight chosen
+
+After a selection (click or free text), all option buttons become disabled. The clicked option is highlighted with emerald styling. If the user typed free text instead, all buttons are disabled with none highlighted. This preserves a clear record of what was asked and answered.
+
+### Placement: Below the message
+
+Option buttons render as a separate block below the assistant's text, not inline. The tool call naturally comes at the end of the LLM's turn, so this is the simplest correct placement.
+
+### No redundant text list
+
+The system prompt instructs the LLM to NOT list options as numbered items in its text response. The buttons ARE the options. The text should provide context and ask the question, then let the buttons speak for themselves.
+
+### 2-4 options max
+
+The tool schema enforces `minItems: 2, maxItems: 4`. This keeps the UI compact (stacked buttons without scrolling) and forces the LLM to present focused, differentiated choices.
+
+### System prompt guidance
+
+Explicit instructions in the `<tools_guidance>` section tell the LLM when to use `present_options` and the rules for using it. Relying solely on the tool description would be less predictable.
+
+### Deferred tool_result
+
+Both Anthropic and OpenAI APIs require a `tool_result` for every `tool_use` before the next API call. Rather than sending a synthetic "waiting for selection" result immediately, we defer the `tool_result` until the user actually responds. At that point, the result contains their real selection (e.g., `"User selected: Software Engineering Manager"`). This gives the LLM maximum context.
+
+### Mixed tools edge case: Error and retry
+
+The system prompt instructs the LLM not to combine `present_options` with other tool calls. If it does anyway, all tool calls receive error `tool_result` messages ("present_options cannot be combined with other tool calls") and the tool loop continues, giving the LLM a chance to retry correctly. This avoids complex partial-execution logic and teaches the LLM to follow the rule.
+
+### State derived from message positions
+
+No new fields on `ChatMessage`, no new reducer actions. Whether options are interactive or disabled is derived from the message array: if a subsequent user message exists after an assistant message with `present_options`, the options are answered. The selected option is identified by matching the next user message's content against option titles. This keeps state management simple and avoids needing to mutate existing messages.
+
+### Reuse existing `handleSend`
+
+Clicking an option calls the same `handleSend(title)` function as typing in the text input. No separate handler needed — the click produces a user message identical to what the user would have typed.

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -7,6 +7,7 @@ import { sendMessage } from '@/lib/llm-client';
 import { buildChatSystemPrompt, RESUME_FORMATTING_SYSTEM_PROMPT } from '@/lib/prompts';
 import { ChatMessage } from '@/components/ChatMessage';
 import { ChatInput } from '@/components/ChatInput';
+import { ChatOptions } from '@/components/ChatOptions';
 import { ChatToolbar } from '@/components/ChatToolbar';
 import { ChatPanel } from '@/components/ChatPanel';
 import { AnswersPanel } from '@/components/AnswersPanel';
@@ -15,7 +16,7 @@ import { ResumePanel } from '@/components/ResumePanel';
 import { CHAT_TOOLS, executeToolCall } from '@/lib/chat-tools';
 import { buildExportMarkdown, downloadTextFile } from '@/lib/export';
 import { ANTHROPIC_FAST_MODEL, OPENAI_FAST_MODEL } from '@/lib/models';
-import type { ChatMessage as ChatMessageType, ToolCall } from '@/types';
+import type { ChatMessage as ChatMessageType, PresentedOption, ToolCall } from '@/types';
 
 export default function ChatPage() {
   const { state, dispatch } = useSession();
@@ -67,6 +68,32 @@ export default function ChatPage() {
 
         if (toolCalls.length === 0) {
           dispatch({ type: 'ADD_CHAT_MESSAGE', message: { role: 'assistant', content } });
+          break;
+        }
+
+        const hasPresentOptions = toolCalls.some((tc) => tc.name === 'present_options');
+        const hasOtherTools = toolCalls.some((tc) => tc.name !== 'present_options');
+
+        if (hasPresentOptions && hasOtherTools) {
+          const assistantMsg: ChatMessageType = { role: 'assistant', content, toolCalls };
+          dispatch({ type: 'ADD_CHAT_MESSAGE', message: assistantMsg });
+          const errorResultMessages: ChatMessageType[] = toolCalls.map((tc) => ({
+            role: 'user' as const,
+            content:
+              'Error: present_options cannot be combined with other tool calls. Use present_options in a separate response.',
+            toolResult: { toolUseId: tc.id },
+          }));
+          for (const trm of errorResultMessages) {
+            dispatch({ type: 'ADD_CHAT_MESSAGE', message: trm });
+          }
+          currentMessages = [...currentMessages, assistantMsg, ...errorResultMessages];
+          setStreamingContent('');
+          continue;
+        }
+
+        if (hasPresentOptions) {
+          const assistantMsg: ChatMessageType = { role: 'assistant', content, toolCalls };
+          dispatch({ type: 'ADD_CHAT_MESSAGE', message: assistantMsg });
           break;
         }
 
@@ -178,10 +205,38 @@ export default function ChatPage() {
     }
   }, [resumeJustUpdated]);
 
+  function getPendingOptionToolResult(
+    messages: ChatMessageType[],
+    userText: string,
+  ): ChatMessageType | null {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.toolResult) continue;
+      if (msg.role === 'user') return null;
+      if (msg.role === 'assistant') {
+        const tc = msg.toolCalls?.find((t) => t.name === 'present_options');
+        if (!tc) return null;
+        return {
+          role: 'user',
+          content: `User selected: ${userText}`,
+          toolResult: { toolUseId: tc.id },
+        };
+      }
+    }
+    return null;
+  }
+
   async function handleSend(text: string) {
+    const pendingResult = getPendingOptionToolResult(state.chatMessages, text);
+    if (pendingResult) {
+      dispatch({ type: 'ADD_CHAT_MESSAGE', message: pendingResult });
+    }
     const userMessage: ChatMessageType = { role: 'user', content: text };
     dispatch({ type: 'ADD_CHAT_MESSAGE', message: userMessage });
-    runChatTurn([...state.chatMessages, userMessage]);
+    const allMessages = pendingResult
+      ? [...state.chatMessages, pendingResult, userMessage]
+      : [...state.chatMessages, userMessage];
+    runChatTurn(allMessages);
   }
 
   function handleDownload() {
@@ -210,10 +265,47 @@ export default function ChatPage() {
 
         <div className="flex-1 overflow-y-auto space-y-1">
           {state.chatMessages
-            .filter((msg) => !msg.toolResult)
-            .map((msg, i) => (
-              <ChatMessage key={i} message={msg} />
-            ))}
+            .map((msg, idx) => ({ msg, idx }))
+            .filter(({ msg }) => !msg.toolResult)
+            .map(({ msg, idx }) => {
+              let optionState: {
+                options: PresentedOption[];
+                disabled: boolean;
+                selectedTitle: string | null;
+              } | null = null;
+
+              if (msg.role === 'assistant') {
+                const tc = msg.toolCalls?.find((t) => t.name === 'present_options');
+                if (tc) {
+                  const options = (tc.input.options as PresentedOption[]) || [];
+                  let disabled = streaming;
+                  let selectedTitle: string | null = null;
+                  for (let j = idx + 1; j < state.chatMessages.length; j++) {
+                    const m = state.chatMessages[j];
+                    if (m.role === 'user' && !m.toolResult) {
+                      disabled = true;
+                      selectedTitle = options.find((o) => o.title === m.content)?.title ?? null;
+                      break;
+                    }
+                  }
+                  optionState = { options, disabled, selectedTitle };
+                }
+              }
+
+              return (
+                <div key={idx}>
+                  <ChatMessage message={msg} />
+                  {optionState && (
+                    <ChatOptions
+                      options={optionState.options}
+                      onSelect={handleSend}
+                      disabled={optionState.disabled}
+                      selectedTitle={optionState.selectedTitle}
+                    />
+                  )}
+                </div>
+              );
+            })}
           {formattingResume && (
             <p className="text-center text-sm text-stone-400 py-8">Preparing your resume...</p>
           )}

--- a/src/components/ChatOptions.tsx
+++ b/src/components/ChatOptions.tsx
@@ -1,0 +1,43 @@
+import type { PresentedOption } from '@/types';
+
+interface ChatOptionsProps {
+  options: PresentedOption[];
+  onSelect: (title: string) => void;
+  disabled: boolean;
+  selectedTitle: string | null;
+}
+
+export function ChatOptions({ options, onSelect, disabled, selectedTitle }: ChatOptionsProps) {
+  if (options.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 mt-1 mb-4 w-full">
+      {options.map((option) => {
+        const isSelected = disabled && selectedTitle === option.title;
+        const isUnselected = disabled && selectedTitle !== option.title;
+
+        return (
+          <button
+            key={option.title}
+            onClick={() => onSelect(option.title)}
+            disabled={disabled}
+            className={`rounded-xl border px-4 py-3 text-left transition-colors ${
+              isSelected
+                ? 'border-emerald-500 bg-emerald-50 text-emerald-900'
+                : isUnselected
+                  ? 'border-stone-200 bg-stone-50 text-stone-400 opacity-60'
+                  : 'border-stone-300 bg-white text-stone-900 hover:border-emerald-500 hover:bg-emerald-50 cursor-pointer'
+            }`}
+          >
+            <span className="block font-medium text-sm">{option.title}</span>
+            <span className={`block text-xs mt-0.5 ${
+              isSelected ? 'text-emerald-700' : isUnselected ? 'text-stone-400' : 'text-stone-500'
+            }`}>
+              {option.description}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/__tests__/chat-tools.test.ts
+++ b/src/lib/__tests__/chat-tools.test.ts
@@ -8,10 +8,11 @@ const SAMPLE_ITEMS = [
 ];
 
 describe('CHAT_TOOLS', () => {
-  it('exports both tool definitions', () => {
-    expect(CHAT_TOOLS).toHaveLength(2);
+  it('exports all tool definitions', () => {
+    expect(CHAT_TOOLS).toHaveLength(3);
     expect(CHAT_TOOLS.map((t) => t.name)).toContain('update_rankings');
     expect(CHAT_TOOLS.map((t) => t.name)).toContain('update_resume');
+    expect(CHAT_TOOLS.map((t) => t.name)).toContain('present_options');
   });
 });
 

--- a/src/lib/chat-tools.ts
+++ b/src/lib/chat-tools.ts
@@ -37,7 +37,39 @@ export const UPDATE_RESUME_TOOL: ToolDefinition = {
   },
 };
 
-export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL, UPDATE_RESUME_TOOL];
+export const PRESENT_OPTIONS_TOOL: ToolDefinition = {
+  name: 'present_options',
+  description:
+    'Present 2-4 clickable options to the user. Use this instead of listing numbered options in text. The user will click one or type a free-text response instead.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      options: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description: 'Short label for the option (sent as user message when clicked)',
+            },
+            description: {
+              type: 'string',
+              description: 'One-sentence explanation of this option',
+            },
+          },
+          required: ['title', 'description'],
+        },
+        minItems: 2,
+        maxItems: 4,
+        description: 'The options to present. Must be 2-4 items.',
+      },
+    },
+    required: ['options'],
+  },
+};
+
+export const CHAT_TOOLS: ToolDefinition[] = [UPDATE_RANKINGS_TOOL, UPDATE_RESUME_TOOL, PRESENT_OPTIONS_TOOL];
 
 export function executeUpdateRankings(
   input: Record<string, unknown>,

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -51,6 +51,18 @@ You also have access to an update_resume tool that can update the user's resume.
 When updating the resume, provide the COMPLETE updated resume as markdown. Always confirm planned changes with the user before calling the tool. After using the tool, briefly describe what was changed.
 
 Resume markdown format: use # for the person's name, *italics* for contact info, ## for section headers, **bold** for job titles/companies, bullet points for responsibilities, and nested bullets for sub-details.
+
+You also have access to a present_options tool that displays clickable buttons to the user. Use it when:
+- You are presenting 2-4 distinct choices for the user to pick from (e.g., dream job scenarios, plan directions)
+- The choices are well-defined enough to have a short title and brief description
+
+Rules for present_options:
+- NEVER list the options as numbered items in your text message. The buttons ARE the options.
+- Your text message should provide context and ask the question, then let the buttons speak for themselves.
+- Always provide 2-4 options.
+- Each option needs a short title and a one-sentence description.
+- Do NOT combine present_options with other tool calls in the same response.
+- The user may click a button OR type a free-text response instead.
 </tools_guidance>
 
 {{REFLECTION_ANSWERS}}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,11 @@ export interface ToolDefinition {
   inputSchema: Record<string, unknown>;
 }
 
+export interface PresentedOption {
+  title: string;
+  description: string;
+}
+
 export type StreamEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_call'; id: string; name: string; input: Record<string, unknown> };


### PR DESCRIPTION
## Summary
- Adds a `present_options` LLM tool that renders 2-4 clickable buttons in the coaching chat when the LLM presents multiple-choice questions (e.g., dream job scenarios, plan directions)
- The tool breaks the auto-execute tool loop and waits for user interaction — clicking a button sends the title as a user message, or the user can type free text instead
- Selected option highlights emerald, unselected ones dim, and the chat input remains active alongside the buttons

## Test plan
- [x] `npm test` — 103 tests pass (updated `CHAT_TOOLS` length assertion to 3)
- [x] `npm run build` — no type errors
- [x] Browser: LLM presents dream job scenarios as clickable buttons (not numbered text)
- [x] Browser: clicking an option sends title as user message, buttons disable, selected one highlights
- [x] Browser: LLM responds with follow-up text and new set of option buttons
- [x] Browser: type free text instead of clicking — buttons disable with none highlighted
- [x] Browser: `update_rankings` / `update_resume` tools still work normally

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)